### PR TITLE
[round-3] 전체 기능 구현 및 테스트

### DIFF
--- a/apps/commerce-api/src/main/java/com/loopers/application/brand/BrandFacade.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/brand/BrandFacade.java
@@ -1,0 +1,23 @@
+package com.loopers.application.brand;
+
+
+import com.loopers.domain.brand.Brand;
+import com.loopers.domain.brand.BrandService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+
+@RequiredArgsConstructor
+@Component
+public class BrandFacade {
+
+    private final BrandService brandService;
+
+    public BrandInfo getBrandDetail(Long brandId) {
+        // service
+        Brand brand = brandService.getBrandDetail(brandId);
+        // domain -> result
+        return BrandInfo.from(brand);
+    }
+
+}

--- a/apps/commerce-api/src/main/java/com/loopers/application/brand/BrandInfo.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/brand/BrandInfo.java
@@ -1,0 +1,22 @@
+package com.loopers.application.brand;
+
+import com.loopers.domain.brand.Brand;
+
+
+public record BrandInfo(
+        Long id,
+        String name,
+        String description,
+        String imageUrl
+) {
+
+    public static BrandInfo from(Brand brand) {
+        return new BrandInfo(
+                brand.getId(),
+                brand.getName(),
+                brand.getDescription(),
+                brand.getImageUrl()
+        );
+    }
+
+}

--- a/apps/commerce-api/src/main/java/com/loopers/application/cart/CartCommand.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/cart/CartCommand.java
@@ -1,0 +1,11 @@
+package com.loopers.application.cart;
+
+
+import java.util.List;
+
+public record CartCommand(
+        String userId,
+        List<CartItemCommand> items
+) {
+
+}

--- a/apps/commerce-api/src/main/java/com/loopers/application/cart/CartFacade.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/cart/CartFacade.java
@@ -1,0 +1,29 @@
+package com.loopers.application.cart;
+
+import com.loopers.domain.cart.Cart;
+import com.loopers.domain.cart.CartService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+
+@RequiredArgsConstructor
+@Component
+public class CartFacade {
+
+    private final CartService cartService;
+
+    public CartInfo addToCart(CartCommand command) {
+        // service
+        Cart cart = cartService.addToCart(command);
+        // domain -> info
+        return CartInfo.from(cart);
+    }
+
+    public CartInfo getMyCart(String userId) {
+        // service
+        Cart cart = cartService.getMyCart(userId);
+        // domain -> info
+        return CartInfo.from(cart);
+    }
+
+}

--- a/apps/commerce-api/src/main/java/com/loopers/application/cart/CartInfo.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/cart/CartInfo.java
@@ -1,0 +1,32 @@
+package com.loopers.application.cart;
+
+import com.loopers.domain.cart.Cart;
+
+import java.util.List;
+
+public record CartInfo(
+        Long cartId,
+        String userId,
+        int totalPrice,
+        List<CartItemInfo> items
+) {
+
+    public static CartInfo from(Cart cart) {
+        List<CartItemInfo> itemInfos = cart.getCartItems().stream()
+                .map(item -> new CartItemInfo(
+                        item.getProduct().getId(),
+                        item.getProduct().getName(),
+                        item.getProduct().getImageUrl(),
+                        item.getQuantity(),
+                        item.getPrice()))
+                .toList();
+
+        return new CartInfo(
+                cart.getId(),
+                cart.getUser().getUserId(),
+                cart.getTotalPrice(),
+                itemInfos
+        );
+    }
+
+}

--- a/apps/commerce-api/src/main/java/com/loopers/application/cart/CartItemCommand.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/cart/CartItemCommand.java
@@ -1,0 +1,10 @@
+package com.loopers.application.cart;
+
+
+public record CartItemCommand(
+        Long productId,
+        int quantity,
+        int price
+) {
+
+}

--- a/apps/commerce-api/src/main/java/com/loopers/application/cart/CartItemFactory.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/cart/CartItemFactory.java
@@ -1,0 +1,35 @@
+package com.loopers.application.cart;
+
+import com.loopers.domain.cart.CartItem;
+import com.loopers.domain.product.Product;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Component
+@RequiredArgsConstructor
+public class CartItemFactory {
+
+    public static List<CartItem> createFrom(
+            List<CartItemCommand> itemCommands,
+            List<Product> products
+    ) {
+
+        Map<Long, Product> productMap = products.stream()
+                .collect(Collectors.toMap(Product::getId, p -> p));
+
+        return itemCommands.stream()
+                .map(cmd -> {
+                    Product product = productMap.get(cmd.productId());
+                    if (product == null) {
+                        throw new IllegalArgumentException("Product not found: " + cmd.productId());
+                    }
+                    return CartItem.create(product, cmd.quantity(), cmd.price());
+                })
+                .toList();
+    }
+
+}

--- a/apps/commerce-api/src/main/java/com/loopers/application/cart/CartItemInfo.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/cart/CartItemInfo.java
@@ -1,0 +1,12 @@
+package com.loopers.application.cart;
+
+
+public record CartItemInfo(
+        Long productId,
+        String productName,
+        String productImageUrl,
+        int quantity,
+        int price
+) {
+
+}

--- a/apps/commerce-api/src/main/java/com/loopers/application/like/LikeContent.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/like/LikeContent.java
@@ -1,14 +1,15 @@
 package com.loopers.application.like;
 
+import com.loopers.domain.like.LikeStatus;
 import com.loopers.domain.product.Product;
 
 public record LikeContent(
         Product product,
         Long likeCount,
-        String likedYn
+        LikeStatus likedYn
 ) {
 
-    public static LikeContent from(Product product, Long likeCount, String likedYn) {
+    public static LikeContent from(Product product, Long likeCount, LikeStatus likedYn) {
         return new LikeContent(
                 product,
                 likeCount,

--- a/apps/commerce-api/src/main/java/com/loopers/application/like/LikeContent.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/like/LikeContent.java
@@ -1,0 +1,19 @@
+package com.loopers.application.like;
+
+import com.loopers.domain.product.Product;
+
+public record LikeContent(
+        Product product,
+        Long likeCount,
+        String likedYn
+) {
+
+    public static LikeContent from(Product product, Long likeCount, String likedYn) {
+        return new LikeContent(
+                product,
+                likeCount,
+                likedYn
+        );
+    }
+
+}

--- a/apps/commerce-api/src/main/java/com/loopers/application/like/LikeFacade.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/like/LikeFacade.java
@@ -1,0 +1,67 @@
+package com.loopers.application.like;
+
+
+import com.loopers.domain.like.Like;
+import com.loopers.domain.like.LikeService;
+import com.loopers.domain.product.Product;
+import com.loopers.domain.product.ProductService;
+import com.loopers.domain.user.User;
+import com.loopers.domain.user.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Map;
+
+
+@RequiredArgsConstructor
+@Component
+public class LikeFacade {
+
+    private final LikeService likeService;
+    private final ProductService productService;
+    private final UserService userService;
+
+    public LikeInfo like(Long productId, String userId) {
+        // 상품, 유저 객체 조회
+        Product product = productService.getProductDetail(productId);
+        User user = userService.getMyInfo(userId); // 유저가 존재하지 않으면 예외 처리 필요 (현재는 통합 테스트 요구사항 때문에 Null로 처리 되어있음)
+
+        // service
+        Like savedLike = likeService.like(product, user);
+        Long likeCount = likeService.getLikeCount(productId);
+
+        // info
+        return LikeInfo.of(savedLike.getLikedYn(), likeCount);
+    }
+
+    public LikeInfo unLike(Long productId, String userId) {
+        // 상품, 유저 객체 조회
+        Product product = productService.getProductDetail(productId);
+        User user = userService.getMyInfo(userId); // 유저가 존재하지 않으면 예외 처리 필요 (현재는 통합 테스트 요구사항 때문에 Null로 처리 되어있음)
+
+        // service
+        Like savedLike = likeService.unLike(product, user);
+        Long likeCount = likeService.getLikeCount(productId);
+
+        // info
+        return LikeInfo.of(savedLike.getLikedYn(), likeCount);
+    }
+
+    public LikeListInfo getLikeProducts(String userId) {
+        // 유저 객체 조회
+        User user = userService.getMyInfo(userId); // 유저가 존재하지 않으면 예외 처리 필요 (현재는 통합 테스트 요구사항 때문에 Null로 처리 되어있음)
+
+        // service
+        List<Like> likeProducts = likeService.getLikeProducts(user);
+
+        List<Long> productIds = likeProducts.stream()
+                .map(like -> like.getProduct().getId())
+                .toList();
+
+        Map<Long, Long> likeCounts = likeService.getLikeCounts(productIds);
+
+        return LikeListInfo.from(likeProducts, likeCounts);
+    }
+
+}

--- a/apps/commerce-api/src/main/java/com/loopers/application/like/LikeInfo.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/like/LikeInfo.java
@@ -1,0 +1,16 @@
+package com.loopers.application.like;
+
+
+public record LikeInfo(
+        String likedYn,
+        Long likeCount
+) {
+
+    public static LikeInfo of(String likedYn, Long likeCount) {
+        return new LikeInfo(
+                likedYn,
+                likeCount
+        );
+    }
+
+}

--- a/apps/commerce-api/src/main/java/com/loopers/application/like/LikeInfo.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/like/LikeInfo.java
@@ -1,12 +1,14 @@
 package com.loopers.application.like;
 
 
+import com.loopers.domain.like.LikeStatus;
+
 public record LikeInfo(
-        String likedYn,
+        LikeStatus likedYn,
         Long likeCount
 ) {
 
-    public static LikeInfo of(String likedYn, Long likeCount) {
+    public static LikeInfo of(LikeStatus likedYn, Long likeCount) {
         return new LikeInfo(
                 likedYn,
                 likeCount

--- a/apps/commerce-api/src/main/java/com/loopers/application/like/LikeListInfo.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/like/LikeListInfo.java
@@ -1,0 +1,25 @@
+package com.loopers.application.like;
+
+import com.loopers.domain.like.Like;
+import com.loopers.domain.product.Product;
+
+import java.util.List;
+import java.util.Map;
+
+public record LikeListInfo(
+        List<LikeContent> contents
+) {
+
+    public static LikeListInfo from(List<Like> likes, Map<Long, Long> likeCounts) {
+        List<LikeContent> likeContents = likes.stream()
+                .map(like -> {
+                    Product product = like.getProduct();
+                    Long likeCount = likeCounts.getOrDefault(product.getId(), 0L);
+                    return LikeContent.from(product, likeCount, like.getLikedYn());
+                })
+                .toList();
+
+        return new LikeListInfo(likeContents);
+    }
+
+}

--- a/apps/commerce-api/src/main/java/com/loopers/application/order/ExternalSendInfo.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/order/ExternalSendInfo.java
@@ -1,0 +1,10 @@
+package com.loopers.application.order;
+
+
+public record ExternalSendInfo(
+        boolean success,
+        String message,
+        String trackingNumber
+) {
+
+}

--- a/apps/commerce-api/src/main/java/com/loopers/application/order/OrderCommand.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/order/OrderCommand.java
@@ -1,0 +1,11 @@
+package com.loopers.application.order;
+
+
+import java.util.List;
+
+public record OrderCommand(
+        String userId,
+        List<OrderItemCommand> items
+) {
+
+}

--- a/apps/commerce-api/src/main/java/com/loopers/application/order/OrderFacade.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/order/OrderFacade.java
@@ -28,7 +28,7 @@ public class OrderFacade {
     public OrderInfo placeOrder(OrderCommand command) {
         // 유저, 포인트 조회
         User user = userService.getMyInfo(command.userId());
-        Point point = pointService.getPoint(command.userId());
+        Point point = pointService.getPoint(user);
 
         // 상품 조회
         List<Long> productIds = command.items().stream()

--- a/apps/commerce-api/src/main/java/com/loopers/application/order/OrderFacade.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/order/OrderFacade.java
@@ -1,0 +1,72 @@
+package com.loopers.application.order;
+
+import com.loopers.domain.order.Order;
+import com.loopers.domain.order.OrderService;
+import com.loopers.domain.point.Point;
+import com.loopers.domain.point.PointService;
+import com.loopers.domain.product.Product;
+import com.loopers.domain.product.ProductService;
+import com.loopers.domain.user.User;
+import com.loopers.domain.user.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+
+@RequiredArgsConstructor
+@Component
+public class OrderFacade {
+
+    private final OrderService orderService;
+    private final UserService userService;
+    private final ProductService productService;
+    private final PointService pointService;
+
+    @Transactional
+    public OrderInfo placeOrder(OrderCommand command) {
+        // 유저, 포인트 조회
+        User user = userService.getMyInfo(command.userId());
+        Point point = pointService.getPoint(command.userId());
+
+        // 상품 조회
+        List<Long> productIds = command.items().stream()
+                .map(OrderItemCommand::productId)
+                .toList();
+        List<Product> products = productService.getProductsByIds(productIds);
+
+        Order order = orderService.createOrder(command.items(), user, point, products);
+
+        // 임시 가정 응답
+        // 주문 정보 외부 시스템 전송
+        // externalOrderSender.send(order);
+        ExternalSendInfo extInfo = new ExternalSendInfo(true, "주문 정보 전송 성공", "EXT-12345");
+
+        // domain -> info
+        return OrderInfo.from(order, extInfo);
+    }
+
+    public List<OrderInfo> getOrders(String userId) {
+        // 유저 정보 조회
+        User user = userService.getMyInfo(userId);
+
+        // 주문 정보 목록 조회
+        List<Order> orders = orderService.getOrders(user);
+
+        // domain -> info
+        return OrderInfo.from(orders);
+    }
+
+    public OrderInfo getOrderDetail(Long orderId, String userId) {
+        // 유저 정보 조회
+        User user = userService.getMyInfo(userId);
+
+        // 주문 상세 정보 조회
+        Order order = orderService.getOrderDetail(orderId, user);
+
+        // domain -> info
+        return OrderInfo.from(order);
+    }
+
+}

--- a/apps/commerce-api/src/main/java/com/loopers/application/order/OrderInfo.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/order/OrderInfo.java
@@ -1,0 +1,51 @@
+package com.loopers.application.order;
+
+
+import com.loopers.domain.order.Order;
+import com.loopers.domain.order.OrderStatus;
+
+import java.util.List;
+
+public record OrderInfo(
+        Long orderId,
+        String userId,
+        int totalPrice,
+        OrderStatus orderStatus,
+        List<OrderItemInfo> items,
+        ExternalSendInfo externalSendInfo
+) {
+
+    public static OrderInfo from(
+            Order order,
+            ExternalSendInfo externalSendInfo
+    ) {
+
+        List<OrderItemInfo> itemInfos = order.getOrderItems().stream()
+                .map(item -> new OrderItemInfo(
+                        item.getProduct().getId(),
+                        item.getProduct().getName(),
+                        item.getQuantity(),
+                        item.getPrice()
+                )).toList();
+
+        return new OrderInfo(
+                order.getId(),
+                order.getUser().getUserId(),
+                order.getTotalPrice(),
+                order.getStatus(),
+                itemInfos,
+                externalSendInfo
+        );
+    }
+
+    public static List<OrderInfo> from(List<Order> orders) {
+        return orders.stream()
+                .map(order -> from(order, null))
+                .toList();
+    }
+
+    public static OrderInfo from(Order order) {
+        return from(order, null);
+    }
+
+}

--- a/apps/commerce-api/src/main/java/com/loopers/application/order/OrderItemCommand.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/order/OrderItemCommand.java
@@ -1,0 +1,10 @@
+package com.loopers.application.order;
+
+
+public record OrderItemCommand(
+        Long productId,
+        int quantity,
+        int price
+) {
+
+}

--- a/apps/commerce-api/src/main/java/com/loopers/application/order/OrderItemFactory.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/order/OrderItemFactory.java
@@ -1,0 +1,36 @@
+package com.loopers.application.order;
+
+import com.loopers.domain.order.OrderItem;
+import com.loopers.domain.product.Product;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Component
+@RequiredArgsConstructor
+public class OrderItemFactory {
+
+    public static List<OrderItem> createFrom(
+            List<OrderItemCommand> itemCommands,
+            List<Product> products
+    ) {
+
+        Map<Long, Product> productMap = products.stream()
+                .collect(Collectors.toMap(Product::getId, p -> p));
+
+        return itemCommands.stream()
+                .map(cmd -> {
+                    Product product = productMap.get(cmd.productId());
+                    if (product == null) {
+                        throw new IllegalArgumentException("Product not found: " + cmd.productId());
+                    }
+                    return OrderItem.create(product, cmd.quantity(), cmd.price());
+                })
+                .toList();
+
+    }
+
+}

--- a/apps/commerce-api/src/main/java/com/loopers/application/order/OrderItemInfo.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/order/OrderItemInfo.java
@@ -1,0 +1,11 @@
+package com.loopers.application.order;
+
+
+public record OrderItemInfo(
+        Long productId,
+        String productName,
+        int quantity,
+        int price
+) {
+
+}

--- a/apps/commerce-api/src/main/java/com/loopers/application/point/PointFacade.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/point/PointFacade.java
@@ -2,6 +2,7 @@ package com.loopers.application.point;
 
 import com.loopers.domain.point.Point;
 import com.loopers.domain.point.PointService;
+import com.loopers.domain.user.User;
 import com.loopers.domain.user.UserService;
 import com.loopers.support.error.CoreException;
 import com.loopers.support.error.ErrorType;
@@ -29,7 +30,8 @@ public class PointFacade {
 
     public PointInfo getPoint(String userId) {
         // service
-        Point point = pointService.getPoint(userId);
+        User user = userService.getMyInfo(userId);
+        Point point = pointService.getPoint(user);
         if (point == null) {
             return null;
         }

--- a/apps/commerce-api/src/main/java/com/loopers/application/point/PointFacade.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/point/PointFacade.java
@@ -4,8 +4,6 @@ import com.loopers.domain.point.Point;
 import com.loopers.domain.point.PointService;
 import com.loopers.domain.user.User;
 import com.loopers.domain.user.UserService;
-import com.loopers.support.error.CoreException;
-import com.loopers.support.error.ErrorType;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
@@ -17,15 +15,11 @@ public class PointFacade {
     private final PointService pointService;
     private final UserService userService;
 
-    @Transactional
     public PointInfo charge(PointCommand command) {
         // validation user exists
-        if (!userService.existsByUserId(command.userId())) {
-            throw new CoreException(ErrorType.NOT_FOUND, "존재하지 않는 유저 ID 입니다.");
-        }
-
+        User user = userService.getMyInfo(command.userId());
         // service
-        Point point = pointService.charge(command);
+        Point point = pointService.charge(user, command.amount());
         // domain -> result
         return PointInfo.from(point);
     }
@@ -35,9 +29,7 @@ public class PointFacade {
         // service
         User user = userService.getMyInfo(userId);
         Point point = pointService.getPoint(user);
-        if (point == null) {
-            return null;
-        }
+
         // domain -> result
         return PointInfo.from(point);
     }

--- a/apps/commerce-api/src/main/java/com/loopers/application/point/PointFacade.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/point/PointFacade.java
@@ -8,6 +8,7 @@ import com.loopers.support.error.CoreException;
 import com.loopers.support.error.ErrorType;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 @RequiredArgsConstructor
 @Component
@@ -16,6 +17,7 @@ public class PointFacade {
     private final PointService pointService;
     private final UserService userService;
 
+    @Transactional
     public PointInfo charge(PointCommand command) {
         // validation user exists
         if (!userService.existsByUserId(command.userId())) {
@@ -28,6 +30,7 @@ public class PointFacade {
         return PointInfo.from(point);
     }
 
+    @Transactional(readOnly = true)
     public PointInfo getPoint(String userId) {
         // service
         User user = userService.getMyInfo(userId);

--- a/apps/commerce-api/src/main/java/com/loopers/application/point/PointInfo.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/point/PointInfo.java
@@ -8,7 +8,7 @@ public record PointInfo(
 ) {
     public static PointInfo from(Point point) {
         return new PointInfo(
-                point.getUserId(),
+                point.getUser().getUserId(),
                 point.getBalance()
         );
     }

--- a/apps/commerce-api/src/main/java/com/loopers/application/product/ProductCommand.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/product/ProductCommand.java
@@ -1,0 +1,36 @@
+package com.loopers.application.product;
+
+
+import com.loopers.domain.product.ProductSearchCondition;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+
+public record ProductCommand(
+        Long brandId,
+        int page,
+        int size,
+        Sort sort
+) {
+
+    public static ProductCommand of(Long brandId, Pageable pageable) {
+        return new ProductCommand(
+                brandId,
+                pageable.getPageNumber(),
+                pageable.getPageSize(),
+                pageable.getSort()
+        );
+    }
+
+    public Pageable toPageable() {
+        return PageRequest.of(page, size, sort);
+    }
+
+    public ProductSearchCondition toCondition() {
+        return new ProductSearchCondition(
+                brandId,
+                toPageable()
+        );
+    }
+
+}

--- a/apps/commerce-api/src/main/java/com/loopers/application/product/ProductCommand.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/product/ProductCommand.java
@@ -23,7 +23,13 @@ public record ProductCommand(
     }
 
     public Pageable toPageable() {
-        return PageRequest.of(page, size, sort);
+        int safePage = Math.max(page, 0);
+        int safeSize = size <= 0 ? 20 : size;
+        Sort safeSort = (sort == null || sort().isEmpty())
+                ? Sort.by(Sort.Direction.DESC, "createdAt")
+                : sort;
+
+        return PageRequest.of(safePage, safeSize, safeSort);
     }
 
     public ProductSearchCondition toCondition() {

--- a/apps/commerce-api/src/main/java/com/loopers/application/product/ProductContent.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/product/ProductContent.java
@@ -1,0 +1,28 @@
+package com.loopers.application.product;
+
+import com.loopers.domain.product.Product;
+
+public record ProductContent(
+        Long id,
+        String name,
+        String description,
+        String imageUrl,
+        int price,
+        Long likeCount,
+        Long brandId,
+        String brandName
+) {
+
+    public static ProductContent from(Product product, Long likeCount) {
+        return new ProductContent(
+                product.getId(),
+                product.getName(),
+                product.getDescription(),
+                product.getImageUrl(),
+                product.getPrice(),
+                likeCount,
+                product.getBrand().getId(),
+                product.getBrand().getName()
+        );
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/application/product/ProductContentBundle.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/product/ProductContentBundle.java
@@ -1,0 +1,27 @@
+package com.loopers.application.product;
+
+import com.loopers.domain.product.Product;
+import org.springframework.data.domain.Page;
+
+import java.util.List;
+import java.util.Map;
+
+public record ProductContentBundle(
+        List<ProductContent> contents
+) {
+
+    public static ProductContentBundle create(
+            Page<Product> products,
+            Map<Long, Long> likeCounts
+    ) {
+        List<ProductContent> productContents = products.getContent().stream()
+                .map(product -> ProductContent.from(
+                        product,
+                        likeCounts.getOrDefault(product.getId(), 0L)
+                ))
+                .toList();
+
+        return new ProductContentBundle(productContents);
+    }
+
+}

--- a/apps/commerce-api/src/main/java/com/loopers/application/product/ProductFacade.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/product/ProductFacade.java
@@ -1,0 +1,51 @@
+package com.loopers.application.product;
+
+
+import com.loopers.domain.like.LikeService;
+import com.loopers.domain.product.Product;
+import com.loopers.domain.product.ProductService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Map;
+
+@RequiredArgsConstructor
+@Component
+public class ProductFacade {
+
+    private final ProductService productService;
+    private final LikeService likeService;
+
+    public ProductListInfo getProducts(ProductCommand command, String userId) {
+        // service
+        Page<Product> products = productService.getProducts(command);
+
+        List<Long> productIds = products.stream()
+                .map(Product::getId)
+                .toList();
+
+        // likeCount
+        Map<Long, Long> likeCounts = likeService.getLikeCounts(productIds);
+
+        // 추후 여유가 생기면 구현 -> 로그인시 likedYn 추가
+
+        // domain -> result
+        return ProductListInfo.from(products, likeCounts);
+    }
+
+    public ProductInfo getProductDetail(Long productId, String userId) {
+        // service
+        Product product = productService.getProductDetail(productId);
+
+        // likeCount
+        Long likeCount = likeService.getLikeCount(productId);
+
+        // 추후 여유가 생기면 구현 -> 로그인시 likedYn 추가
+
+        // domain -> result
+        return ProductInfo.from(product, likeCount);
+    }
+
+}

--- a/apps/commerce-api/src/main/java/com/loopers/application/product/ProductFacade.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/product/ProductFacade.java
@@ -31,8 +31,11 @@ public class ProductFacade {
 
         // 추후 여유가 생기면 구현 -> 로그인시 likedYn 추가
 
+        // product, likeCount mapping VO
+        ProductContentBundle bundle = ProductContentBundle.create(products, likeCounts);
+
         // domain -> result
-        return ProductListInfo.from(products, likeCounts);
+        return ProductListInfo.from(bundle, products.getPageable(), products.getTotalElements());
     }
 
     public ProductInfo getProductDetail(Long productId, String userId) {

--- a/apps/commerce-api/src/main/java/com/loopers/application/product/ProductInfo.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/product/ProductInfo.java
@@ -1,0 +1,30 @@
+package com.loopers.application.product;
+
+import com.loopers.domain.product.Product;
+
+
+public record ProductInfo(
+        Long id,
+        String name,
+        String description,
+        String imageUrl,
+        int price,
+        Long likeCount,
+        Long brandId,
+        String brandName
+) {
+
+    public static ProductInfo from(Product product, Long likeCount) {
+        return new ProductInfo(
+                product.getId(),
+                product.getName(),
+                product.getDescription(),
+                product.getImageUrl(),
+                product.getPrice(),
+                likeCount,
+                product.getBrand().getId(),
+                product.getBrand().getName()
+        );
+    }
+
+}

--- a/apps/commerce-api/src/main/java/com/loopers/application/product/ProductListInfo.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/product/ProductListInfo.java
@@ -1,28 +1,28 @@
 package com.loopers.application.product;
 
-import com.loopers.domain.product.Product;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 import java.util.List;
-import java.util.Map;
 
 public record ProductListInfo(
         List<ProductContent> contents,
-        Pageable pageable
+        int page,
+        int size,
+        long totalElements,
+        int totalPages
 ) {
 
-    public static ProductListInfo from(Page<Product> products, Map<Long, Long> likeCounts) {
-        List<ProductContent> productContents = products.getContent().stream()
-                .map(product -> ProductContent.from(
-                        product,
-                        likeCounts.getOrDefault(product.getId(), 0L).longValue()
-                ))
-                .toList();
-
+    public static ProductListInfo from(
+            ProductContentBundle bundle,
+            Pageable pageable,
+            long totalElements
+    ) {
         return new ProductListInfo(
-                productContents,
-                products.getPageable()
+                bundle.contents(),
+                pageable.getPageNumber(),
+                pageable.getPageSize(),
+                totalElements,
+                (int) Math.ceil((double) totalElements / pageable.getPageSize())
         );
     }
 

--- a/apps/commerce-api/src/main/java/com/loopers/application/product/ProductListInfo.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/product/ProductListInfo.java
@@ -1,0 +1,29 @@
+package com.loopers.application.product;
+
+import com.loopers.domain.product.Product;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+import java.util.Map;
+
+public record ProductListInfo(
+        List<ProductContent> contents,
+        Pageable pageable
+) {
+
+    public static ProductListInfo from(Page<Product> products, Map<Long, Long> likeCounts) {
+        List<ProductContent> productContents = products.getContent().stream()
+                .map(product -> ProductContent.from(
+                        product,
+                        likeCounts.getOrDefault(product.getId(), 0L).longValue()
+                ))
+                .toList();
+
+        return new ProductListInfo(
+                productContents,
+                products.getPageable()
+        );
+    }
+
+}

--- a/apps/commerce-api/src/main/java/com/loopers/application/product/ProductQuantityFactory.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/product/ProductQuantityFactory.java
@@ -1,0 +1,32 @@
+package com.loopers.application.product;
+
+import com.loopers.application.order.OrderItemCommand;
+import com.loopers.domain.product.Product;
+import com.loopers.domain.product.ProductQuantity;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Component
+@RequiredArgsConstructor
+public class ProductQuantityFactory {
+
+    public static List<ProductQuantity> createFrom(
+            List<OrderItemCommand> itemCommands,
+            List<Product> products
+    ) {
+
+        Map<Long, Product> productMap = products.stream()
+                .collect(Collectors.toMap(Product::getId, p -> p));
+
+        return itemCommands.stream()
+                .map(item -> {
+                    return ProductQuantity.of(productMap.get(item.productId()), item.quantity());
+                })
+                .toList();
+    }
+
+}

--- a/apps/commerce-api/src/main/java/com/loopers/application/user/UserCommand.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/user/UserCommand.java
@@ -1,7 +1,6 @@
 package com.loopers.application.user;
 
 import com.loopers.domain.user.Gender;
-import com.loopers.domain.user.User;
 
 public record UserCommand(
         String userId,
@@ -9,14 +8,5 @@ public record UserCommand(
         String birth,
         String email
 ) {
-
-    public static User toDomain(UserCommand command) {
-        return User.create(
-                command.userId,
-                command.gender,
-                command.birth,
-                command.email
-        );
-    }
 
 }

--- a/apps/commerce-api/src/main/java/com/loopers/application/user/UserFacade.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/user/UserFacade.java
@@ -18,7 +18,7 @@ public class UserFacade {
         User user = userService.signUp(command);
 
         // create Point for new user
-        pointService.create(user.getUserId());
+        pointService.create(user);
 
         // domain -> result
         return UserInfo.from(user);

--- a/apps/commerce-api/src/main/java/com/loopers/domain/brand/Brand.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/brand/Brand.java
@@ -14,4 +14,28 @@ public class Brand extends BaseEntity {
     String description;
     String imageUrl;
 
+    public static Brand create(String name, String description, String imageUrl) {
+        Brand brand = new Brand();
+
+        brand.validate(name, imageUrl);
+
+        brand.name = name;
+        brand.description = description;
+        brand.imageUrl = imageUrl;
+
+        return brand;
+    }
+
+    private void validate(String name, String imageUrl) {
+        if (name == null || name.isBlank())
+            throw new IllegalArgumentException("브랜드명은 필수입니다.");
+        if (!name.matches("^[가-힣a-zA-Z0-9]+$"))
+            throw new IllegalArgumentException("브랜드명은 한글, 영어, 숫자만 허용됩니다.");
+
+        if (imageUrl == null || imageUrl.isBlank())
+            throw new IllegalArgumentException("이미지 URL은 필수입니다.");
+        if (!imageUrl.matches("^https?://.*\\.(jpg|jpeg|png|gif|webp|svg)$"))
+            throw new IllegalArgumentException("유효한 이미지 확장자를 가진 URL이어야 합니다.");
+    }
+
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/brand/Brand.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/brand/Brand.java
@@ -3,11 +3,14 @@ package com.loopers.domain.brand;
 import com.loopers.domain.BaseEntity;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Table;
+import lombok.AccessLevel;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
 @Table(name = "brands")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Brand extends BaseEntity {
 
     String name;

--- a/apps/commerce-api/src/main/java/com/loopers/domain/brand/Brand.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/brand/Brand.java
@@ -1,0 +1,17 @@
+package com.loopers.domain.brand;
+
+import com.loopers.domain.BaseEntity;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import lombok.Getter;
+
+@Entity
+@Getter
+@Table(name = "brands")
+public class Brand extends BaseEntity {
+
+    String name;
+    String description;
+    String imageUrl;
+
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/brand/BrandRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/brand/BrandRepository.java
@@ -7,4 +7,6 @@ public interface BrandRepository {
 
     Optional<Brand> findById(Long brandId);
 
+    Brand save(Brand brand);
+
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/brand/BrandRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/brand/BrandRepository.java
@@ -1,0 +1,10 @@
+package com.loopers.domain.brand;
+
+
+import java.util.Optional;
+
+public interface BrandRepository {
+
+    Optional<Brand> findById(Long brandId);
+
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/brand/BrandService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/brand/BrandService.java
@@ -1,0 +1,20 @@
+package com.loopers.domain.brand;
+
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class BrandService {
+
+    private final BrandRepository brandRepository;
+
+    public Brand getBrandDetail(Long brandId) {
+        // repository
+        return brandRepository.findById(brandId).orElseThrow(
+                () -> new IllegalArgumentException("Brand not found with id: " + brandId)
+        );
+    }
+
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/cart/Cart.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/cart/Cart.java
@@ -1,0 +1,56 @@
+package com.loopers.domain.cart;
+
+import com.loopers.domain.BaseEntity;
+import com.loopers.domain.user.User;
+import jakarta.persistence.*;
+import lombok.Getter;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Getter
+@Table(name = "carts")
+public class Cart extends BaseEntity {
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @OneToMany(cascade = CascadeType.ALL)
+    @JoinColumn(name = "cart_id")
+    private List<CartItem> cartItems = new ArrayList<>();
+
+    private int totalPrice;
+
+    public static Cart create(User user) {
+        Cart cart = new Cart();
+
+        cart.validate(user);
+
+        cart.user = user;
+
+        return cart;
+    }
+
+    public void validate(User user) {
+        if (user == null) {
+            throw new NullPointerException("장바구니를 생성할 때 사용자 정보는 필수입니다.");
+        }
+    }
+
+    public void addItem(List<CartItem> items) {
+        if (items == null || items.isEmpty()) {
+            throw new IllegalArgumentException("장바구니 아이템은 필수입니다.");
+        }
+
+        for (CartItem item : items) {
+            if (item == null) {
+                throw new IllegalArgumentException("장바구니 아이템은 null일 수 없습니다.");
+            }
+            cartItems.add(item);
+            totalPrice += item.getPrice() * item.getQuantity();
+        }
+    }
+
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/cart/Cart.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/cart/Cart.java
@@ -3,7 +3,9 @@ package com.loopers.domain.cart;
 import com.loopers.domain.BaseEntity;
 import com.loopers.domain.user.User;
 import jakarta.persistence.*;
+import lombok.AccessLevel;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -11,6 +13,7 @@ import java.util.List;
 @Entity
 @Getter
 @Table(name = "carts")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Cart extends BaseEntity {
 
     @OneToOne(cascade = CascadeType.ALL)

--- a/apps/commerce-api/src/main/java/com/loopers/domain/cart/Cart.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/cart/Cart.java
@@ -13,7 +13,7 @@ import java.util.List;
 @Table(name = "carts")
 public class Cart extends BaseEntity {
 
-    @ManyToOne(fetch = FetchType.LAZY)
+    @OneToOne(cascade = CascadeType.ALL)
     @JoinColumn(name = "user_id")
     private User user;
 

--- a/apps/commerce-api/src/main/java/com/loopers/domain/cart/CartItem.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/cart/CartItem.java
@@ -1,0 +1,45 @@
+package com.loopers.domain.cart;
+
+import com.loopers.domain.BaseEntity;
+import com.loopers.domain.product.Product;
+import jakarta.persistence.*;
+import lombok.Getter;
+
+@Entity
+@Getter
+@Table(name = "cart_items")
+public class CartItem extends BaseEntity {
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "product_id")
+    private Product product;
+
+    int quantity;
+
+    int price;
+
+    public static CartItem create(Product product, int quantity, int price) {
+        CartItem cartItem = new CartItem();
+
+        cartItem.validate(product, quantity, price);
+
+        cartItem.product = product;
+        cartItem.quantity = quantity;
+        cartItem.price = price;
+
+        return cartItem;
+    }
+
+    public void validate(Product product, int quantity, int price) {
+        if (product == null) {
+            throw new NullPointerException("상품은 필수입니다.");
+        }
+        if (quantity <= 0) {
+            throw new IllegalArgumentException("상품 수량은 0보다 커야 합니다.");
+        }
+        if (price <= 0) {
+            throw new IllegalArgumentException("가격은 0보다 커야 합니다.");
+        }
+    }
+
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/cart/CartRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/cart/CartRepository.java
@@ -1,0 +1,14 @@
+package com.loopers.domain.cart;
+
+
+import com.loopers.domain.user.User;
+
+import java.util.Optional;
+
+public interface CartRepository {
+
+    Optional<Cart> findByUser(User user);
+
+    Cart save(Cart cart);
+
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/cart/CartService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/cart/CartService.java
@@ -1,0 +1,49 @@
+package com.loopers.domain.cart;
+
+
+import com.loopers.application.cart.CartCommand;
+import com.loopers.application.cart.CartItemCommand;
+import com.loopers.application.cart.CartItemFactory;
+import com.loopers.domain.product.Product;
+import com.loopers.domain.product.ProductRepository;
+import com.loopers.domain.user.User;
+import com.loopers.domain.user.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class CartService {
+
+    private final CartRepository cartRepository;
+    private final UserRepository userRepository;
+    private final ProductRepository productRepository;
+
+    public Cart addToCart(CartCommand command) {
+        User user = userRepository.findByUserId(command.userId())
+                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다: " + command.userId()));
+
+        Cart cart = cartRepository.findByUser(user)
+                .orElseGet(() -> cartRepository.save(Cart.create(user)));
+
+        List<Long> productIds = command.items().stream()
+                .map(CartItemCommand::productId)
+                .toList();
+        List<Product> products = productRepository.findAllById(productIds);
+
+        cart.addItem(CartItemFactory.createFrom(command.items(), products));
+
+        return cartRepository.save(cart);
+    }
+
+    public Cart getMyCart(String userId) {
+        User user = userRepository.findByUserId(userId)
+                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다: " + userId));
+
+        return cartRepository.findByUser(user)
+                .orElseThrow(() -> new IllegalArgumentException("장바구니를 찾을 수 없습니다: " + userId));
+    }
+
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/like/Like.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/like/Like.java
@@ -21,14 +21,16 @@ public class Like extends BaseEntity {
     @JoinColumn(name = "product_id")
     private Product product;
 
-    private String likedYn;
+    @Enumerated(EnumType.STRING)
+    @Column(name = "liked_yn")
+    private LikeStatus likedYn;
 
     public void like() {
-        this.likedYn = "Y";
+        this.likedYn = LikeStatus.Y;
     }
 
     public void unLike() {
-        this.likedYn = "N";
+        this.likedYn = LikeStatus.N;
     }
 
     public static Like likeOrCreate(Optional<Like> maybeLike, User user, Product product) {
@@ -44,8 +46,12 @@ public class Like extends BaseEntity {
         Like like = new Like();
         like.user = user;
         like.product = product;
-        like.likedYn = "Y";
+        like.likedYn = LikeStatus.Y;
         return like;
+    }
+
+    public boolean isLiked() {
+        return this.likedYn.isLiked();
     }
 
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/like/Like.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/like/Like.java
@@ -4,16 +4,18 @@ import com.loopers.domain.BaseEntity;
 import com.loopers.domain.product.Product;
 import com.loopers.domain.user.User;
 import jakarta.persistence.*;
+import lombok.AccessLevel;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
-import java.util.Optional;
 
 @Entity
 @Getter
 @Table(name = "likes")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Like extends BaseEntity {
 
-    @OneToOne(cascade =  CascadeType.ALL)
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
     private User user;
 
@@ -33,20 +35,13 @@ public class Like extends BaseEntity {
         this.likedYn = LikeStatus.N;
     }
 
-    public static Like likeOrCreate(Optional<Like> maybeLike, User user, Product product) {
-        if (maybeLike.isPresent()) {
-            Like existingLike = maybeLike.get();
-            existingLike.like();
-            return existingLike;
-        }
-        return Like.create(user, product);
-    }
-
     public static Like create(User user, Product product) {
         Like like = new Like();
+
         like.user = user;
         like.product = product;
         like.likedYn = LikeStatus.Y;
+
         return like;
     }
 

--- a/apps/commerce-api/src/main/java/com/loopers/domain/like/Like.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/like/Like.java
@@ -1,0 +1,24 @@
+package com.loopers.domain.like;
+
+import com.loopers.domain.BaseEntity;
+import com.loopers.domain.product.Product;
+import com.loopers.domain.user.User;
+import jakarta.persistence.*;
+import lombok.Getter;
+
+@Entity
+@Getter
+@Table(name = "likes")
+public class Like extends BaseEntity {
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "product_id")
+    private Product product;
+
+    private String likedYn;
+
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/like/Like.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/like/Like.java
@@ -6,6 +6,8 @@ import com.loopers.domain.user.User;
 import jakarta.persistence.*;
 import lombok.Getter;
 
+import java.util.Optional;
+
 @Entity
 @Getter
 @Table(name = "likes")
@@ -20,5 +22,30 @@ public class Like extends BaseEntity {
     private Product product;
 
     private String likedYn;
+
+    public void like() {
+        this.likedYn = "Y";
+    }
+
+    public void unLike() {
+        this.likedYn = "N";
+    }
+
+    public static Like likeOrCreate(Optional<Like> maybeLike, User user, Product product) {
+        if (maybeLike.isPresent()) {
+            Like existingLike = maybeLike.get();
+            existingLike.like();
+            return existingLike;
+        }
+        return Like.create(user, product);
+    }
+
+    public static Like create(User user, Product product) {
+        Like like = new Like();
+        like.user = user;
+        like.product = product;
+        like.likedYn = "Y";
+        return like;
+    }
 
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/like/Like.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/like/Like.java
@@ -13,7 +13,7 @@ import java.util.Optional;
 @Table(name = "likes")
 public class Like extends BaseEntity {
 
-    @ManyToOne(fetch = FetchType.LAZY)
+    @OneToOne(cascade =  CascadeType.ALL)
     @JoinColumn(name = "user_id")
     private User user;
 

--- a/apps/commerce-api/src/main/java/com/loopers/domain/like/LikeRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/like/LikeRepository.java
@@ -1,14 +1,23 @@
 package com.loopers.domain.like;
 
 
+import com.loopers.domain.product.Product;
+import com.loopers.domain.user.User;
 import com.loopers.infrastructure.like.dto.LikeCountDto;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface LikeRepository {
 
     List<LikeCountDto> countGroupByProductIds(List<Long> productIds);
 
     Long countGroupByProductId(Long productId);
+
+    Optional<Like> findByProductAndUser(Product product, User user);
+
+    Like save(Like like);
+
+    List<Like> findByUser(User user);
 
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/like/LikeRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/like/LikeRepository.java
@@ -18,6 +18,6 @@ public interface LikeRepository {
 
     Like save(Like like);
 
-    List<Like> findByUser(User user);
+    List<Like> findByUserJoinProduct(User user);
 
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/like/LikeRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/like/LikeRepository.java
@@ -1,0 +1,14 @@
+package com.loopers.domain.like;
+
+
+import com.loopers.infrastructure.like.dto.LikeCountDto;
+
+import java.util.List;
+
+public interface LikeRepository {
+
+    List<LikeCountDto> countGroupByProductIds(List<Long> productIds);
+
+    Long countGroupByProductId(Long productId);
+
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/like/LikeService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/like/LikeService.java
@@ -50,7 +50,7 @@ public class LikeService {
     }
 
     public List<Like> getLikeProducts(User user) {
-        return likeRepository.findByUser(user);
+        return likeRepository.findByUserJoinProduct(user);
     }
 
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/like/LikeService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/like/LikeService.java
@@ -19,15 +19,24 @@ public class LikeService {
     private final LikeRepository likeRepository;
 
     public Map<Long, Long> getLikeCounts(List<Long> productIds) {
-        return likeRepository.countGroupByProductIds(productIds).stream()
+        Map<Long, Long> likeCountMap = likeRepository.countGroupByProductIds(productIds).stream()
                 .collect(Collectors.toMap(
                         LikeCountDto::getProductId,
                         LikeCountDto::getCount
                 ));
+
+        for (Long id : productIds) {
+            // 좋아요가 0건인 상품은 likeCountMap 에 포함되지 않으므로
+            // 상품 ID가 없으면 0으로 초기화하여 추가함
+            likeCountMap.putIfAbsent(id, 0L);
+        }
+
+        return likeCountMap;
     }
 
     public Long getLikeCount(Long productId) {
-        return likeRepository.countGroupByProductId(productId);
+        return Optional.ofNullable(likeRepository.countGroupByProductId(productId))
+                .orElse(0L);
     }
 
     @Transactional

--- a/apps/commerce-api/src/main/java/com/loopers/domain/like/LikeService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/like/LikeService.java
@@ -41,9 +41,12 @@ public class LikeService {
 
     @Transactional
     public Like like(Product product, User user) {
-        Optional<Like> maybeLike = likeRepository.findByProductAndUser(product, user);
-
-        Like like = Like.likeOrCreate(maybeLike, user, product);
+        Like like = likeRepository.findByProductAndUser(product, user)
+                .map(existingLike -> {
+                    existingLike.like();
+                    return existingLike;
+                })
+                .orElse(Like.create(user, product));
 
         return likeRepository.save(like);
     }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/like/LikeService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/like/LikeService.java
@@ -1,0 +1,29 @@
+package com.loopers.domain.like;
+
+import com.loopers.infrastructure.like.dto.LikeCountDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class LikeService {
+
+    private final LikeRepository likeRepository;
+
+    public Map<Long, Long> getLikeCounts(List<Long> productIds) {
+        return likeRepository.countGroupByProductIds(productIds).stream()
+                .collect(Collectors.toMap(
+                        LikeCountDto::getProductId,
+                        LikeCountDto::getCount
+                ));
+    }
+
+    public Long getLikeCount(Long productId) {
+        return likeRepository.countGroupByProductId(productId);
+    }
+
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/like/LikeService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/like/LikeService.java
@@ -1,11 +1,15 @@
 package com.loopers.domain.like;
 
+import com.loopers.domain.product.Product;
+import com.loopers.domain.user.User;
 import com.loopers.infrastructure.like.dto.LikeCountDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 @Service
@@ -24,6 +28,29 @@ public class LikeService {
 
     public Long getLikeCount(Long productId) {
         return likeRepository.countGroupByProductId(productId);
+    }
+
+    @Transactional
+    public Like like(Product product, User user) {
+        Optional<Like> maybeLike = likeRepository.findByProductAndUser(product, user);
+
+        Like like = Like.likeOrCreate(maybeLike, user, product);
+
+        return likeRepository.save(like);
+    }
+
+    @Transactional
+    public Like unLike(Product product, User user) {
+        Like like = likeRepository.findByProductAndUser(product, user)
+                .orElseThrow(() -> new IllegalArgumentException("Like not found for product and user"));
+
+        like.unLike();
+
+        return likeRepository.save(like);
+    }
+
+    public List<Like> getLikeProducts(User user) {
+        return likeRepository.findByUser(user);
     }
 
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/like/LikeStatus.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/like/LikeStatus.java
@@ -1,0 +1,10 @@
+package com.loopers.domain.like;
+
+public enum LikeStatus {
+    Y, N;
+
+    public boolean isLiked() {
+        return this == Y;
+    }
+
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/order/Order.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/order/Order.java
@@ -3,7 +3,9 @@ package com.loopers.domain.order;
 import com.loopers.domain.BaseEntity;
 import com.loopers.domain.user.User;
 import jakarta.persistence.*;
+import lombok.AccessLevel;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
@@ -13,6 +15,7 @@ import java.util.List;
 @Entity
 @Getter
 @Table(name = "orders")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Order extends BaseEntity {
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/apps/commerce-api/src/main/java/com/loopers/domain/order/Order.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/order/Order.java
@@ -32,6 +32,8 @@ public class Order extends BaseEntity {
     public static Order place(User user, List<OrderItem> items) {
         Order order = new Order();
 
+        order.validate(user, items);
+
         order.user = user;
         for (OrderItem item : items) {
             order.addItem(item);
@@ -43,17 +45,34 @@ public class Order extends BaseEntity {
         return order;
     }
 
+    public void validate(User user, List<OrderItem> items) {
+        if (user == null) {
+            throw new NullPointerException("주문시 사용자 정보는 필수입니다.");
+        }
+        if (items == null || items.isEmpty()) {
+            throw new IllegalArgumentException("주문 아이템은 필수입니다.");
+        }
+    }
+
     public void addItem(OrderItem item) {
+        if (item == null) {
+            throw new IllegalArgumentException("주문 아이템은 null일 수 없습니다.");
+        }
+
         orderItems.add(item);
     }
 
     public int calculateTotalPrice() {
         return orderItems.stream()
-                .mapToInt(OrderItem::getPrice)
+                .mapToInt(item -> item.getPrice() * item.getQuantity())
                 .sum();
     }
 
     public void updateOrderStatus(OrderStatus status) {
+        if (status == null) {
+            throw new IllegalArgumentException("주문 상태는 null일 수 없습니다.");
+        }
+
         this.status = status;
     }
 

--- a/apps/commerce-api/src/main/java/com/loopers/domain/order/Order.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/order/Order.java
@@ -1,0 +1,60 @@
+package com.loopers.domain.order;
+
+import com.loopers.domain.BaseEntity;
+import com.loopers.domain.user.User;
+import jakarta.persistence.*;
+import lombok.Getter;
+
+import java.time.ZonedDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+
+@Entity
+@Getter
+@Table(name = "orders")
+public class Order extends BaseEntity {
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @OneToMany(cascade = CascadeType.ALL)
+    @JoinColumn(name = "order_id")
+    private List<OrderItem> orderItems = new ArrayList<>();
+
+    int totalPrice;
+
+    OrderStatus status;
+
+    ZonedDateTime paidAt;
+
+    public static Order place(User user, List<OrderItem> items) {
+        Order order = new Order();
+
+        order.user = user;
+        for (OrderItem item : items) {
+            order.addItem(item);
+        }
+        order.totalPrice = order.calculateTotalPrice();
+        order.status = OrderStatus.PLACED;
+        order.paidAt = ZonedDateTime.now();
+
+        return order;
+    }
+
+    public void addItem(OrderItem item) {
+        orderItems.add(item);
+    }
+
+    public int calculateTotalPrice() {
+        return orderItems.stream()
+                .mapToInt(OrderItem::getPrice)
+                .sum();
+    }
+
+    public void updateOrderStatus(OrderStatus status) {
+        this.status = status;
+    }
+
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/order/OrderItem.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/order/OrderItem.java
@@ -21,11 +21,25 @@ public class OrderItem extends BaseEntity {
     public static OrderItem create(Product product, int quantity, int price) {
         OrderItem orderItem = new OrderItem();
 
+        orderItem.validate(product, quantity, price);
+
         orderItem.product = product;
         orderItem.quantity = quantity;
         orderItem.price = price;
 
         return orderItem;
+    }
+
+    public void validate(Product product, int quantity, int price) {
+        if (product == null) {
+            throw new NullPointerException("상품은 필수입니다.");
+        }
+        if (quantity <= 0) {
+            throw new IllegalArgumentException("상품 수량은 0보다 커야 합니다.");
+        }
+        if (price <= 0) {
+            throw new IllegalArgumentException("가격은 0보다 커야 합니다.");
+        }
     }
 
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/order/OrderItem.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/order/OrderItem.java
@@ -1,0 +1,31 @@
+package com.loopers.domain.order;
+
+import com.loopers.domain.BaseEntity;
+import com.loopers.domain.product.Product;
+import jakarta.persistence.*;
+import lombok.Getter;
+
+@Entity
+@Getter
+@Table(name = "order_items")
+public class OrderItem extends BaseEntity {
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "product_id")
+    private Product product;
+
+    int quantity;
+
+    int price;
+
+    public static OrderItem create(Product product, int quantity, int price) {
+        OrderItem orderItem = new OrderItem();
+
+        orderItem.product = product;
+        orderItem.quantity = quantity;
+        orderItem.price = price;
+
+        return orderItem;
+    }
+
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/order/OrderRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/order/OrderRepository.java
@@ -4,6 +4,7 @@ package com.loopers.domain.order;
 import com.loopers.domain.user.User;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface OrderRepository {
 
@@ -11,6 +12,6 @@ public interface OrderRepository {
 
     List<Order> findByUser(User user);
 
-    Order findByIdAndUser(Long orderId, User user);
+    Optional<Order> findByIdAndUser(Long orderId, User user);
 
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/order/OrderRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/order/OrderRepository.java
@@ -1,0 +1,16 @@
+package com.loopers.domain.order;
+
+
+import com.loopers.domain.user.User;
+
+import java.util.List;
+
+public interface OrderRepository {
+
+    Order save(Order order);
+
+    List<Order> findByUser(User user);
+
+    Order findByIdAndUser(Long orderId, User user);
+
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/order/OrderService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/order/OrderService.java
@@ -2,56 +2,32 @@ package com.loopers.domain.order;
 
 import com.loopers.application.order.OrderItemCommand;
 import com.loopers.application.order.OrderItemFactory;
-import com.loopers.domain.point.Point;
-import com.loopers.domain.point.PointRepository;
 import com.loopers.domain.product.Product;
-import com.loopers.domain.product.ProductRepository;
 import com.loopers.domain.user.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
 
-
 @Service
 @RequiredArgsConstructor
 public class OrderService {
 
     private final OrderRepository orderRepository;
-    private final ProductRepository productRepository;
-    private final PointRepository pointRepository;
 
     public Order createOrder(
             List<OrderItemCommand> itemCommands,
             User user,
-            Point point,
             List<Product> products
     ) {
-        // 주문 생성
         List<OrderItem> items = OrderItemFactory.createFrom(itemCommands, products);
-        Order order = Order.place(user, items);
 
-        // 상품 재고 차감 (검증 포함)
-        items.forEach(item -> item.getProduct().decreaseStock(item.getQuantity()));
-
-        // 포인트 차감 (검증 포함)
-        Point usedPoint = point.use(order.calculateTotalPrice());
-        // 주문 상태 변경
-        order.updateOrderStatus(OrderStatus.PAID);
-
-        // 주문 저장
-        return save(order, usedPoint);
+        return Order.place(user, items);
     }
 
-    public Order save(Order order, Point point) {
-        // 상품 저장
-        List<Product> products = order.getOrderItems().stream()
-                .map(OrderItem::getProduct)
-                .toList();
-        productRepository.saveAll(products);
-
-        // 포인트 저장
-        pointRepository.save(point);
+    public Order saveOrder(Order order) {
+        // 주문 상태 변경
+        order.updateOrderStatus(OrderStatus.PAID);
 
         return orderRepository.save(order);
     }
@@ -61,7 +37,8 @@ public class OrderService {
     }
 
     public Order getOrderDetail(Long orderId, User user) {
-        return orderRepository.findByIdAndUser(orderId, user);
+        return orderRepository.findByIdAndUser(orderId, user)
+                .orElseThrow(() -> new IllegalArgumentException("주문을 찾을 수 없습니다. orderId: " + orderId));
     }
 
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/order/OrderService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/order/OrderService.java
@@ -1,0 +1,67 @@
+package com.loopers.domain.order;
+
+import com.loopers.application.order.OrderItemCommand;
+import com.loopers.application.order.OrderItemFactory;
+import com.loopers.domain.point.Point;
+import com.loopers.domain.point.PointRepository;
+import com.loopers.domain.product.Product;
+import com.loopers.domain.product.ProductRepository;
+import com.loopers.domain.user.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+
+@Service
+@RequiredArgsConstructor
+public class OrderService {
+
+    private final OrderRepository orderRepository;
+    private final ProductRepository productRepository;
+    private final PointRepository pointRepository;
+
+    public Order createOrder(
+            List<OrderItemCommand> itemCommands,
+            User user,
+            Point point,
+            List<Product> products
+    ) {
+        // 주문 생성
+        List<OrderItem> items = OrderItemFactory.createFrom(itemCommands, products);
+        Order order = Order.place(user, items);
+
+        // 상품 재고 차감 (검증 포함)
+        items.forEach(item -> item.getProduct().decreaseStock(item.getQuantity()));
+
+        // 포인트 차감 (검증 포함)
+        Point usedPoint = point.use(order.calculateTotalPrice());
+        // 주문 상태 변경
+        order.updateOrderStatus(OrderStatus.PAID);
+
+        // 주문 저장
+        return save(order, usedPoint);
+    }
+
+    public Order save(Order order, Point point) {
+        // 상품 저장
+        List<Product> products = order.getOrderItems().stream()
+                .map(OrderItem::getProduct)
+                .toList();
+        productRepository.saveAll(products);
+
+        // 포인트 저장
+        pointRepository.save(point);
+
+        return orderRepository.save(order);
+    }
+
+    public List<Order> getOrders(User user) {
+        return orderRepository.findByUser(user);
+    }
+
+    public Order getOrderDetail(Long orderId, User user) {
+        return orderRepository.findByIdAndUser(orderId, user);
+    }
+
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/order/OrderStatus.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/order/OrderStatus.java
@@ -1,0 +1,20 @@
+package com.loopers.domain.order;
+
+
+public enum OrderStatus {
+
+    PLACED("주문 접수"),
+    PAID("결제 완료"),
+    CANCELED("주문 취소");
+
+    private final String description;
+
+    OrderStatus(String description) {
+        this.description = description;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/point/Point.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/point/Point.java
@@ -10,7 +10,7 @@ import lombok.Getter;
 @Table(name = "points")
 public class Point extends BaseEntity {
 
-    @ManyToOne(fetch = FetchType.LAZY)
+    @OneToOne(cascade = CascadeType.ALL)
     @JoinColumn(name = "user_id")
     private User user;
     private long amount;

--- a/apps/commerce-api/src/main/java/com/loopers/domain/point/Point.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/point/Point.java
@@ -1,8 +1,8 @@
 package com.loopers.domain.point;
 
 import com.loopers.domain.BaseEntity;
-import jakarta.persistence.Entity;
-import jakarta.persistence.Table;
+import com.loopers.domain.user.User;
+import jakarta.persistence.*;
 import lombok.Getter;
 
 @Entity
@@ -10,15 +10,17 @@ import lombok.Getter;
 @Table(name = "points")
 public class Point extends BaseEntity {
 
-    private String userId;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
     private long amount;
     private long balance; // 총 보유 잔액
 
 
-    public static Point create(String userId) {
+    public static Point create(User user) {
         Point point = new Point();
 
-        point.userId = userId;
+        point.user = user;
         point.amount = 0L; // 초기 충전 금액
         point.balance = 0L; // 초기 잔액
 

--- a/apps/commerce-api/src/main/java/com/loopers/domain/point/Point.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/point/Point.java
@@ -3,17 +3,20 @@ package com.loopers.domain.point;
 import com.loopers.domain.BaseEntity;
 import com.loopers.domain.user.User;
 import jakarta.persistence.*;
+import lombok.AccessLevel;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
 @Table(name = "points")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Point extends BaseEntity {
 
     @OneToOne(cascade = CascadeType.ALL)
     @JoinColumn(name = "user_id")
     private User user;
-    private long amount;
+//    private long amount;
     private long balance; // 총 보유 잔액
 
 
@@ -21,7 +24,7 @@ public class Point extends BaseEntity {
         Point point = new Point();
 
         point.user = user;
-        point.amount = 0L; // 초기 충전 금액
+//        point.amount = 0L; // 초기 충전 금액
         point.balance = 0L; // 초기 잔액
 
         return point;
@@ -44,7 +47,7 @@ public class Point extends BaseEntity {
         return this;
     }
 
-    public void validateAmount(long amount, String type) {
+    private void validateAmount(long amount, String type) {
         if (amount <= 0L) {
             throw new IllegalArgumentException(
                     String.format("%s 금액은 0보다 커야 합니다.", type.equals("charge") ? "충전" : "차감")

--- a/apps/commerce-api/src/main/java/com/loopers/domain/point/PointRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/point/PointRepository.java
@@ -1,11 +1,11 @@
 package com.loopers.domain.point;
 
-import java.util.Optional;
+import com.loopers.domain.user.User;
 
 public interface PointRepository {
 
     Point save(Point point);
 
-    Optional<Point> findByUserId(String userId);
+    Point findByUser(User user);
 
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/point/PointService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/point/PointService.java
@@ -27,9 +27,9 @@ public class PointService {
     @Transactional
     public Point charge(PointCommand command) {
         // validation point exists for userId
-        String userId = command.userId();
-        Point point = pointRepository.findByUserId(userId)
-                .orElseThrow(() -> new IllegalArgumentException("Point not found for userId: " + userId));
+        User user = userRepository.findByUserId(command.userId())
+                .orElseThrow(() -> new IllegalArgumentException("User not found with userId: " + command.userId()));
+        Point point = pointRepository.findByUser(user);
 
         // command -> domain
         point.charge(command.amount());
@@ -37,9 +37,9 @@ public class PointService {
         return pointRepository.save(point);
     }
 
-    public Point getPoint(String userId) {
+    public Point getPoint(User user) {
         // repository
-        return pointRepository.findByUserId(userId).orElse(null);
+        return pointRepository.findByUser(user);
     }
 
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/point/PointService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/point/PointService.java
@@ -1,6 +1,8 @@
 package com.loopers.domain.point;
 
 import com.loopers.application.point.PointCommand;
+import com.loopers.domain.user.User;
+import com.loopers.domain.user.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -10,10 +12,14 @@ import org.springframework.transaction.annotation.Transactional;
 public class PointService {
 
     private final PointRepository pointRepository;
+    private final UserRepository userRepository;
 
     public Point create(String userId) {
+        // user
+        User user = userRepository.findByUserId(userId)
+                .orElseThrow(() -> new IllegalArgumentException("User not found with userId: " + userId));
         // create new Point
-        Point point = Point.create(userId);
+        Point point = Point.create(user);
         // repository
         return pointRepository.save(point);
     }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/Product.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/Product.java
@@ -63,4 +63,15 @@ public class Product extends BaseEntity {
             throw new IllegalArgumentException("재고는 0 초과이어야 합니다.");
     }
 
+
+    public void decreaseStock(int quantity) {
+        if (quantity <= 0) {
+            throw new IllegalArgumentException("차감할 재고 수량은 0보다 커야 합니다.");
+        }
+        if (this.stock < quantity) {
+            throw new IllegalStateException("재고가 부족합니다.");
+        }
+        this.stock -= quantity;
+    }
+
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/Product.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/Product.java
@@ -26,4 +26,41 @@ public class Product extends BaseEntity {
 
     String status;
 
+
+    public static Product create(Brand brand, String name, String description, String imageUrl, int price, int stock) {
+        Product product = new Product();
+
+        product.validate(brand, name, imageUrl, price, stock);
+
+        product.brand = brand;
+        product.name = name;
+        product.description = description;
+        product.imageUrl = imageUrl;
+        product.price = price;
+        product.stock = stock;
+        product.status = "ACTIVE"; // 기본 상태를 ACTIVE로 설정
+
+        return product;
+    }
+
+    private void validate(Brand brand, String name, String imageUrl, int price, int stock) {
+        if (brand == null) throw new IllegalArgumentException("브랜드는 필수입니다.");
+
+        if (name == null || name.isBlank())
+            throw new IllegalArgumentException("상품명은 필수입니다.");
+        if (!name.matches("^[가-힣a-zA-Z0-9]+$"))
+            throw new IllegalArgumentException("상품명은 한글, 영어, 숫자만 허용됩니다.");
+
+        if (imageUrl == null || imageUrl.isBlank())
+            throw new IllegalArgumentException("이미지 URL은 필수입니다.");
+        if (!imageUrl.matches("^https?://.*\\.(jpg|jpeg|png|gif|webp|svg)$"))
+            throw new IllegalArgumentException("유효한 이미지 확장자를 가진 URL이어야 합니다.");
+
+        if (price <= 0)
+            throw new IllegalArgumentException("가격은 0 초과이어야 합니다.");
+
+        if (stock <= 0)
+            throw new IllegalArgumentException("재고는 0 초과이어야 합니다.");
+    }
+
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/Product.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/Product.java
@@ -1,0 +1,29 @@
+package com.loopers.domain.product;
+
+import com.loopers.domain.BaseEntity;
+import com.loopers.domain.brand.Brand;
+import jakarta.persistence.*;
+import lombok.Getter;
+
+@Entity
+@Getter
+@Table(name = "products")
+public class Product extends BaseEntity {
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "brand_id")
+    Brand brand;
+
+    String name;
+
+    String description;
+
+    String imageUrl;
+
+    int price;
+
+    int stock;
+
+    String status;
+
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/Product.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/Product.java
@@ -3,11 +3,14 @@ package com.loopers.domain.product;
 import com.loopers.domain.BaseEntity;
 import com.loopers.domain.brand.Brand;
 import jakarta.persistence.*;
+import lombok.AccessLevel;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
 @Table(name = "products")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Product extends BaseEntity {
 
     @ManyToOne(fetch = FetchType.LAZY)
@@ -56,13 +59,12 @@ public class Product extends BaseEntity {
         if (!imageUrl.matches("^https?://.*\\.(jpg|jpeg|png|gif|webp|svg)$"))
             throw new IllegalArgumentException("유효한 이미지 확장자를 가진 URL이어야 합니다.");
 
-        if (price <= 0)
-            throw new IllegalArgumentException("가격은 0 초과이어야 합니다.");
+        if (price < 0)
+            throw new IllegalArgumentException("가격은 0보다 커야 합니다.");
 
         if (stock <= 0)
             throw new IllegalArgumentException("재고는 0 초과이어야 합니다.");
     }
-
 
     public void decreaseStock(int quantity) {
         if (quantity <= 0) {

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductQuantity.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductQuantity.java
@@ -1,0 +1,17 @@
+package com.loopers.domain.product;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor(staticName = "of")
+public class ProductQuantity {
+
+    private final Product product;
+    private final int quantity;
+
+    public void decreaseQuantity(int quantity) {
+        product.decreaseStock(quantity);
+    }
+
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductRepository.java
@@ -1,0 +1,14 @@
+package com.loopers.domain.product;
+
+
+import org.springframework.data.domain.Page;
+
+import java.util.Optional;
+
+public interface ProductRepository {
+
+    Page<Product> findByCondition(ProductSearchCondition condition);
+
+    Optional<Product> findById(Long productId);
+
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductRepository.java
@@ -3,6 +3,7 @@ package com.loopers.domain.product;
 
 import org.springframework.data.domain.Page;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface ProductRepository {
@@ -10,5 +11,7 @@ public interface ProductRepository {
     Page<Product> findByCondition(ProductSearchCondition condition);
 
     Optional<Product> findById(Long productId);
+
+    List<Product> saveAll(List<Product> products);
 
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductRepository.java
@@ -16,4 +16,6 @@ public interface ProductRepository {
 
     List<Product> findAllById(List<Long> productIds);
 
+    Product save(Product product);
+
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductRepository.java
@@ -18,4 +18,6 @@ public interface ProductRepository {
 
     Product save(Product product);
 
+    List<Product> findByAll();
+
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductRepository.java
@@ -14,4 +14,6 @@ public interface ProductRepository {
 
     List<Product> saveAll(List<Product> products);
 
+    List<Product> findAllById(List<Long> productIds);
+
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductSearchCondition.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductSearchCondition.java
@@ -1,0 +1,19 @@
+package com.loopers.domain.product;
+
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+public record ProductSearchCondition(
+        Long brandId,
+        Pageable pageable
+) {
+
+    public PageRequest toPageRequest() {
+        return PageRequest.of(
+                pageable.getPageNumber(),
+                pageable.getPageSize(),
+                pageable.getSort()
+        );
+    }
+
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductService.java
@@ -5,6 +5,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
+
 
 @Service
 @RequiredArgsConstructor
@@ -24,6 +26,11 @@ public class ProductService {
         return productRepository.findById(productId).orElseThrow(
                 () -> new IllegalArgumentException("Product not found with id: " + productId)
         );
+    }
+
+    public List<Product> getProductsByIds(List<Long> productIds) {
+        // repository
+        return productRepository.findAllById(productIds);
     }
 
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductService.java
@@ -33,4 +33,16 @@ public class ProductService {
         return productRepository.findAllById(productIds);
     }
 
+    public List<Product> checkAndDecreaseStock(List<ProductQuantity> productQuantities) {
+        for (ProductQuantity pq : productQuantities) {
+            pq.decreaseQuantity(pq.getQuantity());
+        }
+
+        List<Product> products = productQuantities.stream()
+                        .map(ProductQuantity::getProduct)
+                        .toList();
+
+        return productRepository.saveAll(products);
+    }
+
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductService.java
@@ -1,0 +1,29 @@
+package com.loopers.domain.product;
+
+import com.loopers.application.product.ProductCommand;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.stereotype.Service;
+
+
+@Service
+@RequiredArgsConstructor
+public class ProductService {
+
+    private final ProductRepository productRepository;
+
+    public Page<Product> getProducts(ProductCommand command) {
+        // command -> domain
+        ProductSearchCondition condition = command.toCondition();
+        // repository
+        return productRepository.findByCondition(condition);
+    }
+
+    public Product getProductDetail(Long productId) {
+        // repository
+        return productRepository.findById(productId).orElseThrow(
+                () -> new IllegalArgumentException("Product not found with id: " + productId)
+        );
+    }
+
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/user/User.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/user/User.java
@@ -3,7 +3,9 @@ package com.loopers.domain.user;
 import com.loopers.domain.BaseEntity;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Table;
+import lombok.AccessLevel;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
@@ -12,6 +14,7 @@ import java.time.format.DateTimeParseException;
 @Entity
 @Getter
 @Table(name = "users")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class User extends BaseEntity {
 
     private String userId;
@@ -58,7 +61,7 @@ public class User extends BaseEntity {
     }
 
     public void validateEmail(String email) {
-        if (!email.matches(REGEX_EMAIL)) {
+        if (email == null || !email.matches(REGEX_EMAIL)) {
             throw new IllegalArgumentException("이메일 형식은 xx@yy.zz 이어야 합니다.");
         }
     }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/user/UserService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/user/UserService.java
@@ -20,7 +20,7 @@ public class UserService {
         }
 
         // command -> domain
-        User user = UserCommand.toDomain(command);
+        User user = User.create(command.userId(), command.gender(), command.birth(), command.email());
         // repository
         return userRepository.save(user);
     }
@@ -30,7 +30,8 @@ public class UserService {
     }
 
     public User getMyInfo(String userId) {
-        return userRepository.findByUserId(userId).orElse(null);
+        return userRepository.findByUserId(userId)
+                .orElseThrow(() -> new NullPointerException("User not found with userId: " + userId));
     }
 
 }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/brand/BrandJpaRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/brand/BrandJpaRepository.java
@@ -1,0 +1,9 @@
+package com.loopers.infrastructure.brand;
+
+import com.loopers.domain.brand.Brand;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+
+public interface BrandJpaRepository extends JpaRepository<Brand, Long> {
+
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/brand/BrandRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/brand/BrandRepositoryImpl.java
@@ -1,0 +1,21 @@
+package com.loopers.infrastructure.brand;
+
+import com.loopers.domain.brand.Brand;
+import com.loopers.domain.brand.BrandRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.Optional;
+
+@RequiredArgsConstructor
+@Component
+public class BrandRepositoryImpl implements BrandRepository {
+
+    private final BrandJpaRepository brandJpaRepository;
+
+    @Override
+    public Optional<Brand> findById(Long brandId) {
+        return brandJpaRepository.findById(brandId);
+    }
+
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/brand/BrandRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/brand/BrandRepositoryImpl.java
@@ -18,4 +18,9 @@ public class BrandRepositoryImpl implements BrandRepository {
         return brandJpaRepository.findById(brandId);
     }
 
+    @Override
+    public Brand save(Brand brand) {
+        return brandJpaRepository.save(brand);
+    }
+
 }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/cart/CartJpaRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/cart/CartJpaRepository.java
@@ -1,0 +1,12 @@
+package com.loopers.infrastructure.cart;
+
+import com.loopers.domain.cart.Cart;
+import com.loopers.domain.user.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+
+public interface CartJpaRepository extends JpaRepository<Cart, Long> {
+
+    Cart findByUser(User user);
+
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/cart/CartRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/cart/CartRepositoryImpl.java
@@ -1,0 +1,28 @@
+package com.loopers.infrastructure.cart;
+
+import com.loopers.domain.cart.Cart;
+import com.loopers.domain.cart.CartRepository;
+import com.loopers.domain.user.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.Optional;
+
+
+@RequiredArgsConstructor
+@Component
+public class CartRepositoryImpl implements CartRepository {
+
+    private final CartJpaRepository cartJpaRepository;
+
+    @Override
+    public Optional<Cart> findByUser(User user) {
+        return Optional.ofNullable(cartJpaRepository.findByUser(user));
+    }
+
+    @Override
+    public Cart save(Cart cart) {
+        return cartJpaRepository.save(cart);
+    }
+
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/like/LikeJpaRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/like/LikeJpaRepository.java
@@ -31,14 +31,7 @@ public interface LikeJpaRepository extends JpaRepository<Like, Long> {
         """)
     Long countGroupByProductId(Long productId);
 
-    @Query("""
-            SELECT l
-            FROM Like l
-            WHERE l.product = :product
-                AND l.user = :user
-        """)
     Optional<Like> findByProductAndUser(Product product, User user);
-
 
     @Query("""
             SELECT l

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/like/LikeJpaRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/like/LikeJpaRepository.java
@@ -1,11 +1,14 @@
 package com.loopers.infrastructure.like;
 
 import com.loopers.domain.like.Like;
+import com.loopers.domain.product.Product;
+import com.loopers.domain.user.User;
 import com.loopers.infrastructure.like.dto.LikeCountDto;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
+import java.util.Optional;
 
 
 public interface LikeJpaRepository extends JpaRepository<Like, Long> {
@@ -27,5 +30,16 @@ public interface LikeJpaRepository extends JpaRepository<Like, Long> {
             GROUP BY l.product.id
         """)
     Long countGroupByProductId(Long productId);
+
+    @Query("""
+            SELECT l
+            FROM Like l
+            WHERE l.product = :product
+                AND l.user = :user
+        """)
+    Optional<Like> findByProductAndUser(Product product, User user);
+
+
+    List<Like> findByUser(User user);
 
 }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/like/LikeJpaRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/like/LikeJpaRepository.java
@@ -40,6 +40,13 @@ public interface LikeJpaRepository extends JpaRepository<Like, Long> {
     Optional<Like> findByProductAndUser(Product product, User user);
 
 
-    List<Like> findByUser(User user);
+    @Query("""
+            SELECT l
+            FROM Like l
+            JOIN FETCH l.product p
+            WHERE l.user = :user
+                AND l.likedYn = 'Y'
+        """)
+    List<Like> findByUserJoinProduct(User user);
 
 }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/like/LikeJpaRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/like/LikeJpaRepository.java
@@ -1,0 +1,31 @@
+package com.loopers.infrastructure.like;
+
+import com.loopers.domain.like.Like;
+import com.loopers.infrastructure.like.dto.LikeCountDto;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.List;
+
+
+public interface LikeJpaRepository extends JpaRepository<Like, Long> {
+
+    @Query("""
+            SELECT new com.loopers.infrastructure.like.dto.LikeCountDto(l.product.id, COUNT(l.id))
+            FROM Like l
+            WHERE l.product.id IN :productIds
+                AND l.likedYn = 'Y'
+            GROUP BY l.product.id
+        """)
+    List<LikeCountDto> countGroupByProductIds(List<Long> productIds);
+
+    @Query("""
+            SELECT COUNT(l.id)
+            FROM Like l
+            WHERE l.product.id = :productId
+                AND l.likedYn = 'Y'
+            GROUP BY l.product.id
+        """)
+    Long countGroupByProductId(Long productId);
+
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/like/LikeRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/like/LikeRepositoryImpl.java
@@ -1,11 +1,15 @@
 package com.loopers.infrastructure.like;
 
+import com.loopers.domain.like.Like;
 import com.loopers.domain.like.LikeRepository;
+import com.loopers.domain.product.Product;
+import com.loopers.domain.user.User;
 import com.loopers.infrastructure.like.dto.LikeCountDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
+import java.util.Optional;
 
 @RequiredArgsConstructor
 @Component
@@ -21,6 +25,21 @@ public class LikeRepositoryImpl implements LikeRepository {
     @Override
     public Long countGroupByProductId(Long productId) {
         return likeJpaRepository.countGroupByProductId(productId);
+    }
+
+    @Override
+    public Optional<Like> findByProductAndUser(Product product, User user) {
+        return likeJpaRepository.findByProductAndUser(product, user);
+    }
+
+    @Override
+    public Like save(Like like) {
+        return likeJpaRepository.save(like);
+    }
+
+    @Override
+    public List<Like> findByUser(User user) {
+        return likeJpaRepository.findByUser(user);
     }
 
 }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/like/LikeRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/like/LikeRepositoryImpl.java
@@ -1,0 +1,26 @@
+package com.loopers.infrastructure.like;
+
+import com.loopers.domain.like.LikeRepository;
+import com.loopers.infrastructure.like.dto.LikeCountDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@Component
+public class LikeRepositoryImpl implements LikeRepository {
+
+    private final LikeJpaRepository likeJpaRepository;
+
+    @Override
+    public List<LikeCountDto> countGroupByProductIds(List<Long> productIds) {
+        return likeJpaRepository.countGroupByProductIds(productIds);
+    }
+
+    @Override
+    public Long countGroupByProductId(Long productId) {
+        return likeJpaRepository.countGroupByProductId(productId);
+    }
+
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/like/LikeRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/like/LikeRepositoryImpl.java
@@ -38,8 +38,8 @@ public class LikeRepositoryImpl implements LikeRepository {
     }
 
     @Override
-    public List<Like> findByUser(User user) {
-        return likeJpaRepository.findByUser(user);
+    public List<Like> findByUserJoinProduct(User user) {
+        return likeJpaRepository.findByUserJoinProduct(user);
     }
 
 }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/like/dto/LikeCountDto.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/like/dto/LikeCountDto.java
@@ -1,0 +1,15 @@
+package com.loopers.infrastructure.like.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class LikeCountDto {
+
+    private Long productId;
+    private Long count;
+
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/order/OrderJpaRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/order/OrderJpaRepository.java
@@ -5,12 +5,13 @@ import com.loopers.domain.user.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 
 public interface OrderJpaRepository extends JpaRepository<Order, Long> {
 
     List<Order> findByUser(User user);
 
-    Order findByIdAndUser(Long id, User user);
+    Optional<Order> findByIdAndUser(Long id, User user);
 
 }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/order/OrderJpaRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/order/OrderJpaRepository.java
@@ -1,0 +1,16 @@
+package com.loopers.infrastructure.order;
+
+import com.loopers.domain.order.Order;
+import com.loopers.domain.user.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+
+public interface OrderJpaRepository extends JpaRepository<Order, Long> {
+
+    List<Order> findByUser(User user);
+
+    Order findByIdAndUser(Long id, User user);
+
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/order/OrderRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/order/OrderRepositoryImpl.java
@@ -1,0 +1,33 @@
+package com.loopers.infrastructure.order;
+
+import com.loopers.domain.order.Order;
+import com.loopers.domain.order.OrderRepository;
+import com.loopers.domain.user.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+
+@RequiredArgsConstructor
+@Component
+public class OrderRepositoryImpl implements OrderRepository {
+
+    private final OrderJpaRepository orderJpaRepository;
+
+    @Override
+    public Order save(Order order) {
+        return orderJpaRepository.save(order);
+    }
+
+    @Override
+    public List<Order> findByUser(User user) {
+        return orderJpaRepository.findByUser(user);
+    }
+
+    @Override
+    public Order findByIdAndUser(Long orderId, User user) {
+        return orderJpaRepository.findByIdAndUser(orderId, user);
+    }
+
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/order/OrderRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/order/OrderRepositoryImpl.java
@@ -7,6 +7,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
+import java.util.Optional;
 
 
 @RequiredArgsConstructor
@@ -26,7 +27,7 @@ public class OrderRepositoryImpl implements OrderRepository {
     }
 
     @Override
-    public Order findByIdAndUser(Long orderId, User user) {
+    public Optional<Order> findByIdAndUser(Long orderId, User user) {
         return orderJpaRepository.findByIdAndUser(orderId, user);
     }
 

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/point/PointJpaRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/point/PointJpaRepository.java
@@ -1,13 +1,12 @@
 package com.loopers.infrastructure.point;
 
 import com.loopers.domain.point.Point;
+import com.loopers.domain.user.User;
 import org.springframework.data.jpa.repository.JpaRepository;
-
-import java.util.Optional;
 
 
 public interface PointJpaRepository extends JpaRepository<Point, Long> {
 
-    Optional<Point> findByUserId(String userId);
+    Point findByUser(User user);
 
 }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/point/PointRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/point/PointRepositoryImpl.java
@@ -2,10 +2,10 @@ package com.loopers.infrastructure.point;
 
 import com.loopers.domain.point.Point;
 import com.loopers.domain.point.PointRepository;
+import com.loopers.domain.user.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
-import java.util.Optional;
 
 @RequiredArgsConstructor
 @Component
@@ -19,8 +19,8 @@ public class PointRepositoryImpl implements PointRepository {
     }
 
     @Override
-    public Optional<Point> findByUserId(String userId) {
-        return pointJpaRepository.findByUserId(userId);
+    public Point findByUser(User user) {
+        return pointJpaRepository.findByUser(user);
     }
 
 }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/product/ProductJpaRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/product/ProductJpaRepository.java
@@ -1,0 +1,15 @@
+package com.loopers.infrastructure.product;
+
+import com.loopers.domain.product.Product;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+
+public interface ProductJpaRepository extends JpaRepository<Product, Long> {
+
+    Page<Product> findByBrandId(Long brandId, Pageable pageable);
+
+    Page<Product> findAll(Pageable pageable);
+
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/product/ProductRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/product/ProductRepositoryImpl.java
@@ -48,4 +48,9 @@ public class ProductRepositoryImpl implements ProductRepository {
         return productJpaRepository.save(product);
     }
 
+    @Override
+    public List<Product> findByAll() {
+        return productJpaRepository.findAll();
+    }
+
 }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/product/ProductRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/product/ProductRepositoryImpl.java
@@ -38,4 +38,9 @@ public class ProductRepositoryImpl implements ProductRepository {
         return productJpaRepository.saveAll(products);
     }
 
+    @Override
+    public List<Product> findAllById(List<Long> productIds) {
+        return productJpaRepository.findAllById(productIds);
+    }
+
 }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/product/ProductRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/product/ProductRepositoryImpl.java
@@ -1,0 +1,35 @@
+package com.loopers.infrastructure.product;
+
+import com.loopers.domain.product.Product;
+import com.loopers.domain.product.ProductRepository;
+import com.loopers.domain.product.ProductSearchCondition;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.stereotype.Component;
+
+import java.util.Optional;
+
+@RequiredArgsConstructor
+@Component
+public class ProductRepositoryImpl implements ProductRepository {
+
+    private final ProductJpaRepository productJpaRepository;
+
+    @Override
+    public Page<Product> findByCondition(ProductSearchCondition condition) {
+        if (condition.brandId() != null) {
+            return productJpaRepository.findByBrandId(
+                    condition.brandId(),
+                    condition.toPageRequest()
+            );
+        } else {
+            return productJpaRepository.findAll(condition.toPageRequest());
+        }
+    }
+
+    @Override
+    public Optional<Product> findById(Long productId) {
+        return productJpaRepository.findById(productId);
+    }
+
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/product/ProductRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/product/ProductRepositoryImpl.java
@@ -43,4 +43,9 @@ public class ProductRepositoryImpl implements ProductRepository {
         return productJpaRepository.findAllById(productIds);
     }
 
+    @Override
+    public Product save(Product product) {
+        return productJpaRepository.save(product);
+    }
+
 }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/product/ProductRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/product/ProductRepositoryImpl.java
@@ -7,6 +7,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Component;
 
+import java.util.List;
 import java.util.Optional;
 
 @RequiredArgsConstructor
@@ -30,6 +31,11 @@ public class ProductRepositoryImpl implements ProductRepository {
     @Override
     public Optional<Product> findById(Long productId) {
         return productJpaRepository.findById(productId);
+    }
+
+    @Override
+    public List<Product> saveAll(List<Product> products) {
+        return productJpaRepository.saveAll(products);
     }
 
 }

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/brand/BrandController.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/brand/BrandController.java
@@ -1,0 +1,30 @@
+package com.loopers.interfaces.api.brand;
+
+import com.loopers.application.brand.BrandFacade;
+import com.loopers.application.brand.BrandInfo;
+import com.loopers.interfaces.api.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/v1/brands")
+public class BrandController implements BrandV1ApiSpec {
+
+    private final BrandFacade brandFacade;
+
+    @GetMapping("/{brandId}")
+    @Override
+    public ApiResponse<BrandV1Dto.BrandResponse> getBrandDetail(
+            @PathVariable Long brandId
+    ) {
+        // facade 호출
+        BrandInfo info = brandFacade.getBrandDetail(brandId);
+        // result -> response
+        BrandV1Dto.BrandResponse response = BrandV1Dto.BrandResponse.from(info);
+
+        return ApiResponse.success(response);
+    }
+
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/brand/BrandV1ApiSpec.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/brand/BrandV1ApiSpec.java
@@ -1,0 +1,26 @@
+package com.loopers.interfaces.api.brand;
+
+import com.loopers.interfaces.api.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.web.bind.annotation.PathVariable;
+
+
+@Tag(name = "Brand V1 API", description = "브랜드(Brand) API 입니다.")
+public interface BrandV1ApiSpec {
+
+    @Operation(
+            summary = "브랜드 정보 조회",
+            description = "브랜드 ID로 브랜드 정보를 조회합니다."
+    )
+    ApiResponse<BrandV1Dto.BrandResponse> getBrandDetail(
+            @Parameter(
+                    name = "brandId",
+                    description = "브랜드 ID (경로 변수)",
+                    required = true
+            )
+            @PathVariable Long brandId
+    );
+
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/brand/BrandV1Dto.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/brand/BrandV1Dto.java
@@ -1,0 +1,24 @@
+package com.loopers.interfaces.api.brand;
+
+
+import com.loopers.application.brand.BrandInfo;
+
+public class BrandV1Dto {
+
+    public record BrandResponse(
+            Long id,
+            String name,
+            String description,
+            String imageUrl
+    ) {
+        public static BrandResponse from(BrandInfo info) {
+            return new BrandResponse(
+                    info.id(),
+                    info.name(),
+                    info.description(),
+                    info.imageUrl()
+            );
+        }
+    }
+
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/cart/CartController.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/cart/CartController.java
@@ -1,0 +1,49 @@
+package com.loopers.interfaces.api.cart;
+
+
+import com.loopers.application.cart.CartCommand;
+import com.loopers.application.cart.CartFacade;
+import com.loopers.application.cart.CartInfo;
+import com.loopers.interfaces.api.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/v1/carts")
+public class CartController implements CartV1ApiSpec {
+
+    private final CartFacade cartFacade;
+
+    @PostMapping("")
+    @Override
+    public ApiResponse<CartV1Dto.CartResponse> addToCart(
+            @RequestBody CartV1Dto.CartRequest request,
+            @RequestHeader("X-USER-ID") String userId
+    ) {
+        // request -> command
+        CartCommand command = request.toCommand(userId);
+        // facade
+        CartInfo info = cartFacade.addToCart(command);
+        // info -> response
+        if (info == null) {
+            return ApiResponse.success(CartV1Dto.CartResponse.fail());
+        }
+        return ApiResponse.success(CartV1Dto.CartResponse.success());
+    }
+
+    @GetMapping("")
+    @Override
+    public ApiResponse<CartV1Dto.CartItemListResponse> getMyCart(
+            @RequestHeader("X-USER-ID") String userId
+    ) {
+        // facade
+        CartInfo info = cartFacade.getMyCart(userId);
+        // info -> response
+        CartV1Dto.CartItemListResponse response = CartV1Dto.CartItemListResponse.from(info);
+
+        return ApiResponse.success(response);
+    }
+
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/cart/CartItemV1Dto.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/cart/CartItemV1Dto.java
@@ -1,0 +1,40 @@
+package com.loopers.interfaces.api.cart;
+
+import com.loopers.application.cart.CartItemCommand;
+import com.loopers.application.cart.CartItemInfo;
+
+public class CartItemV1Dto {
+
+    public record CartItemRequest(
+            Long productId,
+            int quantity,
+            int price
+    ) {
+        public CartItemCommand toCommand() {
+            return new CartItemCommand(
+                    productId,
+                    quantity,
+                    price
+            );
+        }
+    }
+
+    public record CartItemResponse(
+            Long productId,
+            String productName,
+            String productImageUrl,
+            int quantity,
+            int price
+    ) {
+        public static CartItemResponse from(CartItemInfo info) {
+            return new CartItemResponse(
+                    info.productId(),
+                    info.productName(),
+                    info.productImageUrl(),
+                    info.quantity(),
+                    info.price()
+            );
+        }
+    }
+
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/cart/CartV1ApiSpec.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/cart/CartV1ApiSpec.java
@@ -1,0 +1,46 @@
+package com.loopers.interfaces.api.cart;
+
+import com.loopers.interfaces.api.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+
+
+@Tag(name = "Cart V1 API", description = "장바구니(Cart) API 입니다.")
+public interface CartV1ApiSpec {
+
+    @Operation(
+            summary = "장바구니 담기 요청",
+            description = "장바구니에 상품을 담는 요청입니다."
+    )
+    ApiResponse<CartV1Dto.CartResponse> addToCart(
+            @Parameter(
+                    name = "request",
+                    description = "장바구니에 담을 상품 정보",
+                    required = true
+            )
+            @RequestBody CartV1Dto.CartRequest request,
+            @Parameter(
+                    name = "X-USER-ID",
+                    description = "유저 ID (헤더)",
+                    required = true
+            )
+            @RequestHeader("X-USER-ID") String userId
+    );
+
+    @Operation(
+            summary = "장바구니 조회 요청",
+            description = "장바구니에 담긴 상품들을 조회하는 요청입니다."
+    )
+    ApiResponse<CartV1Dto.CartItemListResponse> getMyCart(
+            @Parameter(
+                    name = "X-USER-ID",
+                    description = "유저 ID (헤더)",
+                    required = true
+            )
+            @RequestHeader("X-USER-ID") String userId
+    );
+
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/cart/CartV1Dto.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/cart/CartV1Dto.java
@@ -1,0 +1,58 @@
+package com.loopers.interfaces.api.cart;
+
+
+import com.loopers.application.cart.CartCommand;
+import com.loopers.application.cart.CartInfo;
+import com.loopers.application.cart.CartItemCommand;
+
+import java.util.List;
+
+public class CartV1Dto {
+
+    public record CartRequest(
+            List<CartItemV1Dto.CartItemRequest> items
+    ) {
+        public CartCommand toCommand(String userId) {
+            List<CartItemCommand> itemCommands = this.items.stream()
+                    .map(CartItemV1Dto.CartItemRequest::toCommand)
+                    .toList();
+
+            return new CartCommand(userId, itemCommands);
+        }
+    }
+
+    public record CartResponse(
+            String status,
+            String message
+    ) {
+
+        public static CartResponse fail() {
+            return new CartResponse("fail", "장바구니에 상품을 추가할 수 없습니다.");
+        }
+
+        public static CartResponse success() {
+            return new CartResponse("success", "장바구니에 상품을 추가했습니다.");
+        }
+
+    }
+
+    public record CartItemListResponse(
+            String userId,
+            int totalPrice,
+            List<CartItemV1Dto.CartItemResponse> items
+    ) {
+        public static CartItemListResponse from(CartInfo info) {
+            List<CartItemV1Dto.CartItemResponse> itemResponses = info.items().stream()
+                    .map(CartItemV1Dto.CartItemResponse::from)
+                    .toList();
+
+            return new CartItemListResponse(
+                    info.userId(),
+                    info.totalPrice(),
+                    itemResponses
+            );
+        }
+
+    }
+
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/like/LikeController.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/like/LikeController.java
@@ -1,0 +1,59 @@
+package com.loopers.interfaces.api.like;
+
+import com.loopers.application.like.LikeFacade;
+import com.loopers.application.like.LikeInfo;
+import com.loopers.application.like.LikeListInfo;
+import com.loopers.interfaces.api.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/v1/likes")
+public class LikeController implements LikeV1ApiSpec {
+
+    private final LikeFacade likeFacade;
+
+    @PostMapping("/products/{productId}")
+    @Override
+    public ApiResponse<LikeV1Dto.LikeResponse> like(
+            @PathVariable Long productId,
+            @RequestHeader("X-USER-ID") String userId
+    ) {
+        // facade
+        LikeInfo info = likeFacade.like(productId, userId);
+        // info -> response
+        LikeV1Dto.LikeResponse response = LikeV1Dto.LikeResponse.from(info);
+
+        return ApiResponse.success(response);
+    }
+
+
+    @DeleteMapping("/products/{productId}")
+    @Override
+    public ApiResponse<LikeV1Dto.LikeResponse>  unLike(
+            @PathVariable Long productId,
+            @RequestHeader("X-USER-ID") String userId
+    ) {
+        // facade
+        LikeInfo info = likeFacade.unLike(productId, userId);
+        // info -> response
+        LikeV1Dto.LikeResponse response = LikeV1Dto.LikeResponse.from(info);
+
+        return ApiResponse.success(response);
+    }
+
+//    @GetMapping("/products")
+    @GetMapping("/me")
+    @Override
+    public ApiResponse<LikeV1Dto.LikeListResponse> getMyLikes(@RequestHeader("X-USER-ID") String userId) {
+        // facade
+        LikeListInfo info = likeFacade.getLikeProducts(userId);
+        // info -> response
+        LikeV1Dto.LikeListResponse response = LikeV1Dto.LikeListResponse.from(info);
+
+        return ApiResponse.success(response);
+    }
+
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/like/LikeV1ApiSpec.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/like/LikeV1ApiSpec.java
@@ -1,0 +1,65 @@
+package com.loopers.interfaces.api.like;
+
+import com.loopers.interfaces.api.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestHeader;
+
+
+@Tag(name = "Like V1 API", description = "좋아요(Like) API 입니다.")
+public interface LikeV1ApiSpec {
+
+    @Operation(
+        summary = "상품 좋아요 등록",
+        description = "상품 좋아요를 등록합니다."
+    )
+    ApiResponse<LikeV1Dto.LikeResponse> like(
+            @Parameter(
+                    name = "productId",
+                    description = "상품 ID (경로 변수)",
+                    required = true
+            )
+            @PathVariable Long productId,
+            @Parameter(
+                    name = "X-USER-ID",
+                    description = "유저 ID (헤더)",
+                    required = true
+            )
+            @RequestHeader("X-USER-ID") String userId
+    );
+
+    @Operation(
+            summary = "상품 좋아요 취소",
+            description = "상품 좋아요를 취소합니다."
+    )
+    ApiResponse<LikeV1Dto.LikeResponse> unLike(
+            @Parameter(
+                    name = "productId",
+                    description = "상품 ID (경로 변수)",
+                    required = true
+            )
+            @PathVariable Long productId,
+            @Parameter(
+                    name = "X-USER-ID",
+                    description = "유저 ID (헤더)",
+                    required = true
+            )
+            @RequestHeader("X-USER-ID") String userId
+    );
+
+    @Operation(
+            summary = "내가 좋아요 한 상품 목록 조회",
+            description = "내가 좋아요 한 상품 목록을 조회합니다."
+    )
+    ApiResponse<LikeV1Dto.LikeListResponse> getMyLikes(
+            @Parameter(
+                    name = "X-USER-ID",
+                    description = "유저 ID (헤더)",
+                    required = true
+            )
+            @RequestHeader("X-USER-ID") String userId
+    );
+
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/like/LikeV1Dto.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/like/LikeV1Dto.java
@@ -4,6 +4,7 @@ package com.loopers.interfaces.api.like;
 import com.loopers.application.like.LikeContent;
 import com.loopers.application.like.LikeInfo;
 import com.loopers.application.like.LikeListInfo;
+import com.loopers.domain.like.LikeStatus;
 import com.loopers.domain.product.Product;
 
 import java.util.List;
@@ -11,7 +12,7 @@ import java.util.List;
 public class LikeV1Dto {
 
     public record LikeResponse(
-            String likedYn,
+            LikeStatus likedYn,
             Long likeCount
     ) {
         public static LikeResponse from(LikeInfo info) {
@@ -28,7 +29,7 @@ public class LikeV1Dto {
             String productImageUrl,
             int productPrice,
             Long likeCount,
-            String likedYn
+            LikeStatus likedYn
     ) {
         public static LikeContentResponse from(LikeContent content) {
             Product product = content.product();

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/like/LikeV1Dto.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/like/LikeV1Dto.java
@@ -1,0 +1,51 @@
+package com.loopers.interfaces.api.like;
+
+
+import com.loopers.application.like.LikeContent;
+import com.loopers.application.like.LikeInfo;
+import com.loopers.application.like.LikeListInfo;
+import com.loopers.domain.product.Product;
+
+import java.util.List;
+
+public class LikeV1Dto {
+
+    public record LikeResponse(
+            String likedYn,
+            Long likeCount
+    ) {
+        public static LikeResponse from(LikeInfo info) {
+            return new LikeResponse(
+                    info.likedYn(),
+                    info.likeCount()
+            );
+        }
+    }
+
+    public record LikeContentResponse(
+            Product product,
+            Long likeCount,
+            String likedYn
+    ) {
+        public static LikeContentResponse from(LikeContent content) {
+            return new LikeContentResponse(
+                    content.product(),
+                    content.likeCount(),
+                    content.likedYn()
+            );
+        }
+    }
+
+    public record LikeListResponse(
+            List<LikeContentResponse> contents
+    ) {
+        public static LikeListResponse from(LikeListInfo info) {
+            return new LikeListResponse(
+                    info.contents().stream()
+                            .map(LikeContentResponse::from)
+                            .toList()
+            );
+        }
+    }
+
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/like/LikeV1Dto.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/like/LikeV1Dto.java
@@ -23,13 +23,20 @@ public class LikeV1Dto {
     }
 
     public record LikeContentResponse(
-            Product product,
+            Long productId,
+            String productName,
+            String productImageUrl,
+            int productPrice,
             Long likeCount,
             String likedYn
     ) {
         public static LikeContentResponse from(LikeContent content) {
+            Product product = content.product();
             return new LikeContentResponse(
-                    content.product(),
+                    product.getId(),
+                    product.getName(),
+                    product.getImageUrl(),
+                    product.getPrice(),
                     content.likeCount(),
                     content.likedYn()
             );

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/order/OrderController.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/order/OrderController.java
@@ -1,0 +1,64 @@
+package com.loopers.interfaces.api.order;
+
+import com.loopers.application.order.OrderCommand;
+import com.loopers.application.order.OrderFacade;
+import com.loopers.application.order.OrderInfo;
+import com.loopers.interfaces.api.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/v1/orders")
+public class OrderController implements OrderV1ApiSpec {
+
+    private final OrderFacade orderFacade;
+
+    @PostMapping("")
+    @Override
+    public ApiResponse<OrderV1Dto.OrderResponse> placeOrder(
+            @RequestBody OrderV1Dto.OrderRequest request,
+            @RequestHeader("X-USER-ID") String userId
+    ) {
+        // request -> command
+        OrderCommand command = request.toCommand(userId);
+        // facade
+        OrderInfo info = orderFacade.placeOrder(command);
+        // info -> response
+        OrderV1Dto.OrderResponse response = OrderV1Dto.OrderResponse.from(info);
+
+        return ApiResponse.success(response);
+    }
+
+
+    @GetMapping("")
+    @Override
+    public ApiResponse<OrderV1Dto.OrderListResponse> getOrders(
+            @RequestHeader("X-USER-ID") String userId
+    ) {
+        // facade
+        List<OrderInfo> infos = orderFacade.getOrders(userId);
+        // info -> response
+        OrderV1Dto.OrderListResponse response = OrderV1Dto.OrderListResponse.from(infos);
+
+        return ApiResponse.success(response);
+    }
+
+    @GetMapping("/{orderId}")
+    @Override
+    public ApiResponse<OrderV1Dto.OrderResponse> getOrder(
+            @PathVariable Long orderId,
+            @RequestHeader("X-USER-ID") String userId
+    ) {
+        // facade
+        OrderInfo info = orderFacade.getOrderDetail(orderId, userId);
+        // info -> response
+        OrderV1Dto.OrderResponse response = OrderV1Dto.OrderResponse.from(info);
+
+        return ApiResponse.success(response);
+    }
+
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/order/OrderItemV1Dto.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/order/OrderItemV1Dto.java
@@ -1,0 +1,38 @@
+package com.loopers.interfaces.api.order;
+
+import com.loopers.application.order.OrderItemCommand;
+import com.loopers.application.order.OrderItemInfo;
+
+public class OrderItemV1Dto {
+
+    public record OrderItemRequest(
+            Long productId,
+            int quantity,
+            int price
+    ) {
+        public OrderItemCommand toCommand() {
+            return new OrderItemCommand(
+                    productId,
+                    quantity,
+                    price
+            );
+        }
+    }
+
+    public record OrderItemResponse(
+            Long productId,
+            String productName,
+            int quantity,
+            int price
+    ) {
+        public static OrderItemResponse from(OrderItemInfo info) {
+            return new OrderItemResponse(
+                    info.productId(),
+                    info.productName(),
+                    info.quantity(),
+                    info.price()
+            );
+        }
+    }
+
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/order/OrderV1ApiSpec.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/order/OrderV1ApiSpec.java
@@ -1,0 +1,66 @@
+package com.loopers.interfaces.api.order;
+
+import com.loopers.interfaces.api.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+
+
+@Tag(name = "Order V1 API", description = "주문/결제(Order) API 입니다.")
+public interface OrderV1ApiSpec {
+
+    @Operation(
+        summary = "주문 요청",
+        description = "유저가 상품을 주문하고, 성공하면 주문 ID를 반환합니다."
+    )
+    ApiResponse<OrderV1Dto.OrderResponse> placeOrder(
+            @Parameter(
+                    name = "request",
+                    description = "주문 정보",
+                    required = true
+            )
+            @RequestBody OrderV1Dto.OrderRequest request,
+            @Parameter(
+                    name = "X-USER-ID",
+                    description = "유저 ID (헤더)",
+                    required = true
+            )
+            @RequestHeader("X-USER-ID") String userId
+    );
+
+    @Operation(
+            summary = "유저의 주문 목록 조회",
+            description = "유저의 주문 목록을 조회합니다."
+    )
+    ApiResponse<OrderV1Dto.OrderListResponse> getOrders(
+            @Parameter(
+                    name = "X-USER-ID",
+                    description = "유저 ID (헤더)",
+                    required = true
+            )
+            @RequestHeader("X-USER-ID") String userId
+    );
+
+    @Operation(
+            summary = "단일 주문 상세 조회",
+            description = "주문 ID를 통해 단일 주문의 상세 정보를 조회합니다."
+    )
+    ApiResponse<OrderV1Dto.OrderResponse> getOrder(
+            @Parameter(
+                    name = "orderId",
+                    description = "주문 ID (경로 변수)",
+                    required = true
+            )
+            @PathVariable Long orderId,
+            @Parameter(
+                    name = "X-USER-ID",
+                    description = "유저 ID (헤더)",
+                    required = true
+            )
+            @RequestHeader("X-USER-ID") String userId
+    );
+
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/order/OrderV1Dto.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/order/OrderV1Dto.java
@@ -1,0 +1,65 @@
+package com.loopers.interfaces.api.order;
+
+
+import com.loopers.application.order.ExternalSendInfo;
+import com.loopers.application.order.OrderCommand;
+import com.loopers.application.order.OrderInfo;
+import com.loopers.application.order.OrderItemCommand;
+import com.loopers.domain.order.OrderStatus;
+
+import java.util.List;
+
+public class OrderV1Dto {
+
+    public record OrderRequest(
+            List<OrderItemV1Dto.OrderItemRequest> items
+    ) {
+        public OrderCommand toCommand(String userId) {
+            List<OrderItemCommand> itemCommands = this.items.stream()
+                    .map(OrderItemV1Dto.OrderItemRequest::toCommand)
+                    .toList();
+
+            return new OrderCommand(userId, itemCommands);
+        }
+
+    }
+
+    public record OrderResponse(
+            Long orderId,
+            String userId,
+            int totalPrice,
+            OrderStatus orderStatus,
+            List<OrderItemV1Dto.OrderItemResponse> items,
+            ExternalSendInfo externalSendInfo
+    ) {
+        public static OrderResponse from(OrderInfo info) {
+            List<OrderItemV1Dto.OrderItemResponse> itemResponses = info.items().stream()
+                    .map(OrderItemV1Dto.OrderItemResponse::from)
+                    .toList();
+
+            return new OrderResponse(
+                    info.orderId(),
+                    info.userId(),
+                    info.totalPrice(),
+                    info.orderStatus(),
+                    itemResponses,
+                    info.externalSendInfo()
+            );
+        }
+
+    }
+
+    public record OrderListResponse(
+            List<OrderResponse> orders
+    ) {
+
+        public static OrderListResponse from(List<OrderInfo> infos) {
+            List<OrderResponse> responses = infos.stream()
+                    .map(OrderResponse::from)
+                    .toList();
+
+            return new OrderListResponse(responses);
+        }
+    }
+
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/product/ProductController.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/product/ProductController.java
@@ -1,0 +1,52 @@
+package com.loopers.interfaces.api.product;
+
+import com.loopers.application.product.ProductCommand;
+import com.loopers.application.product.ProductFacade;
+import com.loopers.application.product.ProductInfo;
+import com.loopers.application.product.ProductListInfo;
+import com.loopers.interfaces.api.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.web.bind.annotation.*;
+
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/v1/products")
+public class ProductController implements ProductV1ApiSpec{
+
+    private final ProductFacade productFacade;
+
+    @GetMapping("")
+    @Override
+    public ApiResponse<ProductV1Dto.ProductListResponse> getProducts(
+            @RequestParam (required = false) Long brandId,
+            @PageableDefault(size = 20, sort = "createdAt") Pageable pageable,
+            @RequestHeader("X-USER-ID") String userId
+    ) {
+        // command 생성
+        ProductCommand command = ProductCommand.of(brandId, pageable);
+        // facade 호출
+        ProductListInfo productListInfo = productFacade.getProducts(command, userId);
+        // result -> response
+        ProductV1Dto.ProductListResponse response = ProductV1Dto.ProductListResponse.from(productListInfo);
+
+        return ApiResponse.success(response);
+    }
+
+    @GetMapping("/{productId}")
+    @Override
+    public ApiResponse<ProductV1Dto.ProductDetailResponse> getProductDetail(
+            @PathVariable Long productId,
+            @RequestHeader("X-USER-ID") String userId
+    ) {
+        // facade 호출
+        ProductInfo productInfo = productFacade.getProductDetail(productId, userId);
+        // result -> response
+        ProductV1Dto.ProductDetailResponse response = ProductV1Dto.ProductDetailResponse.from(productInfo);
+
+        return ApiResponse.success(response);
+    }
+
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/product/ProductV1ApiSpec.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/product/ProductV1ApiSpec.java
@@ -1,0 +1,61 @@
+package com.loopers.interfaces.api.product;
+
+import com.loopers.interfaces.api.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestParam;
+
+
+@Tag(name = "Product V1 API", description = "상품(Product) API 입니다.")
+public interface ProductV1ApiSpec {
+
+    @Operation(
+        summary = "상품 목록 조회",
+        description = "상품 목록을 조회합니다."
+    )
+    ApiResponse<ProductV1Dto.ProductListResponse> getProducts(
+            @Parameter(
+                    name = "brandId",
+                    description = "브랜드 ID (쿼리 파라미터)",
+                    required = false
+            )
+            @RequestParam Long brandId,
+            @Parameter(
+                    name = "pageable",
+                    description = "페이징 정보 (쿼리 파라미터)",
+                    required = false
+            )
+            @PageableDefault(size = 20, sort = "createdAt") Pageable pageable,
+            @Parameter(
+                    name = "X-USER-ID",
+                    description = "유저 ID (헤더)",
+                    required = false
+            )
+            @RequestHeader("X-USER-ID") String userId
+    );
+
+    @Operation(
+            summary = "상품 정보 조회",
+            description = "상품 ID로 상품 정보를 조회합니다."
+    )
+    ApiResponse<ProductV1Dto.ProductDetailResponse> getProductDetail(
+            @Parameter(
+                    name = "productId",
+                    description = "상품 ID (경로 변수)",
+                    required = true
+            )
+            @PathVariable Long productId,
+            @Parameter(
+                name = "X-USER-ID",
+                description = "유저 ID (헤더)",
+                required = false
+            )
+            @RequestHeader("X-USER-ID") String userId
+    );
+
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/product/ProductV1Dto.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/product/ProductV1Dto.java
@@ -3,7 +3,6 @@ package com.loopers.interfaces.api.product;
 import com.loopers.application.product.ProductContent;
 import com.loopers.application.product.ProductInfo;
 import com.loopers.application.product.ProductListInfo;
-import org.springframework.data.domain.Pageable;
 
 import java.util.List;
 
@@ -11,7 +10,10 @@ public class ProductV1Dto {
 
     public record ProductListResponse(
             List<ProductContentResponse> contents,
-            Pageable pageable
+            int page,
+            int size,
+            long totalElements,
+            int totalPages
     ) {
         public static ProductListResponse from(ProductListInfo info) {
             List<ProductContentResponse> contentResponses = info.contents().stream()
@@ -20,7 +22,10 @@ public class ProductV1Dto {
 
             return new ProductListResponse(
                     contentResponses,
-                    info.pageable()
+                    info.page(),
+                    info.size(),
+                    info.totalElements(),
+                    info.totalPages()
             );
         }
     }

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/product/ProductV1Dto.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/product/ProductV1Dto.java
@@ -1,0 +1,76 @@
+package com.loopers.interfaces.api.product;
+
+import com.loopers.application.product.ProductContent;
+import com.loopers.application.product.ProductInfo;
+import com.loopers.application.product.ProductListInfo;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+
+public class ProductV1Dto {
+
+    public record ProductListResponse(
+            List<ProductContentResponse> contents,
+            Pageable pageable
+    ) {
+        public static ProductListResponse from(ProductListInfo info) {
+            List<ProductContentResponse> contentResponses = info.contents().stream()
+                    .map(ProductContentResponse::from)
+                    .toList();
+
+            return new ProductListResponse(
+                    contentResponses,
+                    info.pageable()
+            );
+        }
+    }
+
+    public record ProductContentResponse(
+            Long id,
+            String name,
+            String description,
+            String imageUrl,
+            int price,
+            Long likeCount,
+            Long brandId,
+            String brandName
+    ) {
+        public static ProductContentResponse from(ProductContent content) {
+            return new ProductContentResponse(
+                    content.id(),
+                    content.name(),
+                    content.description(),
+                    content.imageUrl(),
+                    content.price(),
+                    content.likeCount(),
+                    content.brandId(),
+                    content.brandName()
+            );
+        }
+    }
+
+    public record ProductDetailResponse(
+            Long id,
+            String name,
+            String description,
+            String imageUrl,
+            int price,
+            Long likeCount,
+            Long brandId,
+            String brandName
+    ) {
+        public static ProductDetailResponse from(ProductInfo info) {
+            return new ProductDetailResponse(
+                    info.id(),
+                    info.name(),
+                    info.description(),
+                    info.imageUrl(),
+                    info.price(),
+                    info.likeCount(),
+                    info.brandId(),
+                    info.brandName()
+            );
+        }
+    }
+
+}

--- a/apps/commerce-api/src/test/java/com/loopers/application/point/PointFacadeIntegrationTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/application/point/PointFacadeIntegrationTest.java
@@ -3,6 +3,7 @@ package com.loopers.application.point;
 import com.loopers.application.user.UserCommand;
 import com.loopers.application.user.UserFacade;
 import com.loopers.domain.user.Gender;
+import com.loopers.domain.user.UserService;
 import com.loopers.support.error.CoreException;
 import com.loopers.support.error.ErrorType;
 import com.loopers.utils.DatabaseCleanUp;
@@ -12,6 +13,7 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
@@ -69,6 +71,7 @@ class PointFacadeIntegrationTest {
 
         @DisplayName("해당 ID 의 회원이 존재할 경우, 보유 포인트가 반환된다.")
         @Test
+        @Transactional
         void returnsBalance_whenUserExistsByUserId() {
             // given
             String userId = "oyy";

--- a/apps/commerce-api/src/test/java/com/loopers/application/point/PointFacadeIntegrationTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/application/point/PointFacadeIntegrationTest.java
@@ -3,9 +3,6 @@ package com.loopers.application.point;
 import com.loopers.application.user.UserCommand;
 import com.loopers.application.user.UserFacade;
 import com.loopers.domain.user.Gender;
-import com.loopers.domain.user.UserService;
-import com.loopers.support.error.CoreException;
-import com.loopers.support.error.ErrorType;
 import com.loopers.utils.DatabaseCleanUp;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
@@ -46,17 +43,12 @@ class PointFacadeIntegrationTest {
         @Test
         void failToCharge_whenUserIdDoesNotExist() {
             // given
-            PointCommand command = new PointCommand("oyy", 500L);
+            PointCommand command = new PointCommand("oyy2", 500L);
 
             // when & then
-            CoreException exception = assertThrows(CoreException.class, () -> {
+            assertThrows(NullPointerException.class, () -> {
                 pointFacade.charge(command);
             });
-
-            assertAll(
-                    () -> assertThat(exception.getMessage()).isEqualTo("존재하지 않는 유저 ID 입니다."),
-                    () -> assertThat(exception.getErrorType()).isEqualTo(ErrorType.NOT_FOUND)
-            );
         }
 
     }
@@ -94,18 +86,16 @@ class PointFacadeIntegrationTest {
             );
         }
 
-        @DisplayName("해당 ID 의 회원이 존재하지 않을 경우, null 이 반환된다.")
+        @DisplayName("해당 ID 의 회원이 존재하지 않을 경우, null 이 반환된다.(예외 발생)")
         @Test
         void returnsNull_whenUserDoesNotExist() {
             // given
             String userId = "oyy";
 
-            // when
-            PointInfo pointInfo = pointFacade.getPoint(userId);
-
-            // then
-            assertThat(pointInfo).isNull();
-            assertThat(pointInfo).isEqualTo(null);
+            // when & then
+            assertThrows(NullPointerException.class, () -> {
+                pointFacade.getPoint(userId);
+            });
         }
     }
 

--- a/apps/commerce-api/src/test/java/com/loopers/domain/brand/BrandServiceIntegrationTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/brand/BrandServiceIntegrationTest.java
@@ -1,0 +1,75 @@
+package com.loopers.domain.brand;
+
+import com.loopers.utils.DatabaseCleanUp;
+import org.junit.jupiter.api.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@SpringBootTest
+class BrandServiceIntegrationTest {
+
+    @Autowired
+    private BrandService brandService;
+
+    @Autowired
+    private BrandRepository brandRepository;
+
+    @Autowired
+    private DatabaseCleanUp databaseCleanUp;
+
+    private Brand testBrand;
+
+    @BeforeEach
+    void setupTestData() {
+        testBrand = brandRepository.save(Brand.create(
+                "브랜드명",
+                "브랜드설명",
+                "https://example.com/brand-image.jpg"
+        ));
+    }
+
+    @AfterEach
+    void cleanDatabase() {
+        databaseCleanUp.truncateAllTables();
+    }
+
+    @DisplayName("브랜드 정보 조회 시,")
+    @Nested
+    class getBrandDetail {
+
+        @DisplayName("존재하는 브랜드 ID로 조회 시, 정상적으로 브랜드 정보를 반환한다.")
+        @Test
+        void successToGetBrandDetail_whenBrandExists() {
+            // given
+            Long brandId = testBrand.getId();
+
+            // when
+            Brand brand = brandService.getBrandDetail(brandId);
+
+            // then
+            assertAll(
+                () -> assertThat(brand).isNotNull(),
+                () -> assertThat(brand.getId()).isEqualTo(brandId),
+                () -> assertThat(brand.getName()).isNotBlank()
+            );
+        }
+
+        @DisplayName("존재하지 않는 브랜드 ID로 조회 시, 예외가 발생한다.")
+        @Test
+        void failToGetBrandDetail_whenBrandDoesNotExist() {
+            // given
+            Long nonExistentBrandId = 999L;
+
+            // when & then
+            assertThrows(IllegalArgumentException.class, () ->
+                    brandService.getBrandDetail(nonExistentBrandId)
+            );
+        }
+
+    }
+
+}

--- a/apps/commerce-api/src/test/java/com/loopers/domain/brand/BrandTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/brand/BrandTest.java
@@ -1,0 +1,68 @@
+package com.loopers.domain.brand;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class BrandTest {
+
+    @DisplayName("브랜드 생성 시,")
+    @Nested
+    class CreateBrand {
+
+        @DisplayName("브랜드명은 한글 또는 영어, 숫자만 허용되며, 공백이나 특수문자가 포함되면 예외가 발생한다.")
+        @ParameterizedTest
+        @ValueSource(strings = {
+                "",
+                "brand#@#",
+                "1  23",
+                "!#$%^&*()",
+        })
+        void throwsIllegalArgumentException_whenNameIsInvalid(String name) {
+            assertThrows(IllegalArgumentException.class, () -> {
+                Brand.create(
+                        name,
+                        "브랜드 설명",
+                        "https://example.com/image.jpg"
+                );
+            });
+        }
+
+        @DisplayName("imageUrl이 빈 문자열이거나 형식이 올바르지 않으면 예외가 발생한다.")
+        @ParameterizedTest
+        @ValueSource(strings = {
+                "",
+                "invalid-url",
+                "https://example.com/image.txt",
+                "https://example.com/image"
+        })
+        void throwsIllegalArgumentException_whenUrlIsInvalid(String url) {
+            assertThrows(IllegalArgumentException.class, () -> {
+                Brand.create(
+                        "브랜드명",
+                        "브랜드 설명",
+                        url
+                );
+            });
+        }
+
+        @DisplayName("정상적인 값이면 Brand가 생성된다.")
+        @Test
+        void success_whenAllValueAreValid() {
+            Brand brand = Brand.create(
+                    "브랜드명",
+                    "브랜드 설명",
+                    "https://example.com/image.jpg"
+            );
+
+            assertNotNull(brand);
+            assertEquals("브랜드명", brand.getName());
+            assertEquals("https://example.com/image.jpg", brand.getImageUrl());
+        }
+    }
+
+}

--- a/apps/commerce-api/src/test/java/com/loopers/domain/cart/CartItemTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/cart/CartItemTest.java
@@ -1,0 +1,95 @@
+package com.loopers.domain.cart;
+
+import com.loopers.domain.brand.Brand;
+import com.loopers.domain.product.Product;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class CartItemTest {
+
+    @DisplayName("CartItem 생성 시,")
+    @Nested
+    class CreateCartItem {
+
+        Brand dummyBrand = new Brand();
+
+        @DisplayName("성공한다.")
+        @Test
+        void success_createCartItem() {
+            // given
+            Product product = Product.create(
+                    dummyBrand,
+                    "상품명",
+                    "상품설명",
+                    "https://example.com/image.jpg",
+                    1000,
+                    10
+            );
+            int quantity = 2;
+            int price = 1000;
+
+            // when
+            CartItem cartItem = CartItem.create(product, quantity, price);
+
+            // then
+            assertAll(
+                    () -> assertEquals(product, cartItem.getProduct()),
+                    () -> assertEquals(quantity, cartItem.getQuantity()),
+                    () -> assertEquals(price, cartItem.getPrice())
+            );
+        }
+
+        @DisplayName("상품 수량이 0 이하이면 예외가 발생한다.")
+        @ParameterizedTest
+        @ValueSource(ints = {0, -1, -100})
+        void throwsIllegalArgumentException_whenQuantityIsNegative(int quantity) {
+            // given
+            Product product = Product.create(
+                    dummyBrand,
+                    "상품명",
+                    "상품설명",
+                    "https://example.com/image.jpg",
+                    1000,
+                    10
+            );
+
+            // when & then
+            assertThrows(IllegalArgumentException.class, () ->
+                    CartItem.create(product, quantity, 1000)
+            );
+        }
+
+        @DisplayName("가격이 0 이하이면 예외가 발생한다.")
+        @ParameterizedTest
+        @ValueSource(ints = {0, -1, -100})
+        void throwsIllegalArgumentException_whenPriceIsNegative(int price) {
+            // given
+            Product product = Product.create(
+                    dummyBrand,
+                    "상품명",
+                    "상품설명",
+                    "https://example.com/image.jpg",
+                    1000,
+                    10
+            );
+
+            // when & then
+            assertThrows(IllegalArgumentException.class, () ->
+                    CartItem.create(product, 1, price)
+            );
+        }
+
+        @DisplayName("상품이 null이면 예외가 발생한다.")
+        @Test
+        void throwsNullPointerException_whenProductIsNull() {
+            assertThrows(NullPointerException.class, () ->
+                    CartItem.create(null, 1, 1000)
+            );
+        }
+    }
+}

--- a/apps/commerce-api/src/test/java/com/loopers/domain/cart/CartItemTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/cart/CartItemTest.java
@@ -2,6 +2,7 @@ package com.loopers.domain.cart;
 
 import com.loopers.domain.brand.Brand;
 import com.loopers.domain.product.Product;
+import com.loopers.support.TestFixture;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -12,11 +13,11 @@ import static org.junit.jupiter.api.Assertions.*;
 
 class CartItemTest {
 
+    Brand dummyBrand = TestFixture.createBrand();
+
     @DisplayName("CartItem 생성 시,")
     @Nested
     class CreateCartItem {
-
-        Brand dummyBrand = new Brand();
 
         @DisplayName("성공한다.")
         @Test

--- a/apps/commerce-api/src/test/java/com/loopers/domain/cart/CartServiceIntegrationTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/cart/CartServiceIntegrationTest.java
@@ -52,10 +52,10 @@ class CartServiceIntegrationTest {
         savedBrand = brandRepository.save(brand);
     }
 
-//    @AfterEach
-//    void cleanDatabase() {
-//        databaseCleanUp.truncateAllTables();
-//    }
+    @AfterEach
+    void cleanDatabase() {
+        databaseCleanUp.truncateAllTables();
+    }
 
     @DisplayName("장바구니 담기 시,")
     @Nested

--- a/apps/commerce-api/src/test/java/com/loopers/domain/cart/CartServiceIntegrationTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/cart/CartServiceIntegrationTest.java
@@ -1,0 +1,156 @@
+package com.loopers.domain.cart;
+
+import com.loopers.application.cart.CartCommand;
+import com.loopers.application.cart.CartItemCommand;
+import com.loopers.domain.brand.Brand;
+import com.loopers.domain.brand.BrandRepository;
+import com.loopers.domain.product.Product;
+import com.loopers.domain.product.ProductRepository;
+import com.loopers.domain.user.User;
+import com.loopers.domain.user.UserRepository;
+import com.loopers.utils.DatabaseCleanUp;
+import org.junit.jupiter.api.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@SpringBootTest
+class CartServiceIntegrationTest {
+
+    @Autowired
+    private CartService cartService;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private BrandRepository brandRepository;
+
+    @Autowired
+    private ProductRepository productRepository;
+
+    @Autowired
+    private DatabaseCleanUp databaseCleanUp;
+
+    private User savedUser;
+
+    private Brand savedBrand;
+
+    @BeforeEach
+    void setUp() {
+        User user = new User();
+        savedUser = userRepository.save(user);
+
+        Brand brand = new Brand();
+        savedBrand = brandRepository.save(brand);
+    }
+
+//    @AfterEach
+//    void cleanDatabase() {
+//        databaseCleanUp.truncateAllTables();
+//    }
+
+    @DisplayName("장바구니 담기 시,")
+    @Nested
+    class AddToCart {
+
+        @DisplayName("정상적으로 담기면 장바구니가 반환된다.")
+        @Test
+        void success() {
+            // given
+            Product product = Product.create(
+                    savedBrand,
+                    "상품명",
+                    "상품설명",
+                    "https://example.com/image.jpg",
+                    1000,
+                    10
+            );
+            Product savedProduct = productRepository.save(product);
+
+            CartItemCommand itemCommand = new CartItemCommand(
+                    savedProduct.getId(),
+                    2,
+                    1000
+            );
+            CartCommand command = new CartCommand(savedUser.getUserId(), List.of(itemCommand));
+
+            // when
+            Cart cart = cartService.addToCart(command);
+
+            // then
+            assertAll(
+                    () -> assertThat(cart.getUser().getId()).isEqualTo(savedUser.getId()),
+                    () -> assertThat(cart.getCartItems()).hasSize(1),
+                    () -> assertThat(cart.getTotalPrice()).isEqualTo(2000)
+            );
+        }
+
+        @DisplayName("유저가 존재하지 않으면 예외가 발생한다.")
+        @Test
+        void fail_userNotFound() {
+            // given
+            CartItemCommand itemCommand = new CartItemCommand(1L, 2, 1000);
+            CartCommand command = new CartCommand("unknown_user", List.of(itemCommand));
+
+            // when & then
+            assertThrows(IllegalArgumentException.class, () -> cartService.addToCart(command));
+        }
+    }
+
+    @DisplayName("내 장바구니 조회 시,")
+    @Nested
+    class GetMyCart {
+
+        @DisplayName("정상적으로 조회된다.")
+        @Test
+        @Transactional
+        void success() {
+            // given
+            Product product = Product.create(
+                    savedBrand,
+                    "상품명",
+                    "상품설명",
+                    "https://example.com/image.jpg",
+                    1000,
+                    5
+            );
+            Product savedProduct = productRepository.save(product);
+
+            CartItemCommand itemCommand = new CartItemCommand(
+                    savedProduct.getId(),
+                    1,
+                    1000
+            );
+            CartCommand command = new CartCommand(savedUser.getUserId(), List.of(itemCommand));
+            cartService.addToCart(command);
+
+            // when
+            Cart cart = cartService.getMyCart(savedUser.getUserId());
+
+            // then
+            assertThat(cart).isNotNull();
+            assertThat(cart.getCartItems()).hasSize(1);
+        }
+
+        @DisplayName("유저가 존재하지 않으면 예외가 발생한다.")
+        @Test
+        void fail_userNotFound() {
+            assertThrows(IllegalArgumentException.class, () -> cartService.getMyCart("no_user"));
+        }
+
+        @DisplayName("장바구니가 존재하지 않으면 예외가 발생한다.")
+        @Test
+        void fail_cartNotFound() {
+            assertThrows(IllegalArgumentException.class, () -> cartService.getMyCart(savedUser.getUserId()));
+        }
+    }
+
+}

--- a/apps/commerce-api/src/test/java/com/loopers/domain/cart/CartServiceIntegrationTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/cart/CartServiceIntegrationTest.java
@@ -8,6 +8,7 @@ import com.loopers.domain.product.Product;
 import com.loopers.domain.product.ProductRepository;
 import com.loopers.domain.user.User;
 import com.loopers.domain.user.UserRepository;
+import com.loopers.support.TestFixture;
 import com.loopers.utils.DatabaseCleanUp;
 import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -16,7 +17,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
-import static org.junit.jupiter.api.Assertions.*;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -45,10 +45,10 @@ class CartServiceIntegrationTest {
 
     @BeforeEach
     void setUp() {
-        User user = new User();
+        User user = TestFixture.createUser();
         savedUser = userRepository.save(user);
 
-        Brand brand = new Brand();
+        Brand brand = TestFixture.createBrand();
         savedBrand = brandRepository.save(brand);
     }
 

--- a/apps/commerce-api/src/test/java/com/loopers/domain/cart/CartTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/cart/CartTest.java
@@ -1,0 +1,100 @@
+package com.loopers.domain.cart;
+
+import com.loopers.domain.brand.Brand;
+import com.loopers.domain.product.Product;
+import com.loopers.domain.user.User;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class CartTest {
+
+    @DisplayName("create()")
+    @Nested
+    class CreateCart {
+
+        @DisplayName("사용자 정보가 있으면 장바구니 생성에 성공한다.")
+        @Test
+        void success() {
+            // given
+            User user = new User();
+
+            // when
+            Cart cart = Cart.create(user);
+
+            // then
+            assertNotNull(cart);
+            assertNotNull(cart.getId());
+            assertEquals(user, cart.getUser());
+        }
+
+        @DisplayName("사용자 정보가 null이면 예외가 발생한다.")
+        @Test
+        void failWhenUserIsNull() {
+            assertThrows(NullPointerException.class, () -> Cart.create(null));
+        }
+    }
+
+
+    @DisplayName("addItem()")
+    @Nested
+    class AddItem {
+
+        Brand dummyBrand = new Brand();
+        Product product = Product.create(
+                dummyBrand,
+                "상품명",
+                "상품설명",
+                "https://example.com/image.jpg",
+                1000,
+                10
+        );
+
+        @DisplayName("장바구니 아이템 추가에 성공한다.")
+        @Test
+        void success() {
+            // given
+            Cart cart = Cart.create(new User());
+            CartItem item1 = CartItem.create(product, 2, 1000);
+            CartItem item2 = CartItem.create(product, 1, 2000);
+
+            // when
+            cart.addItem(List.of(item1, item2));
+
+            // then
+            assertAll(
+                    () -> assertEquals(2, cart.getCartItems().size()),
+                    () -> assertEquals(1000 * 2 + 2000 * 1, cart.getTotalPrice())
+            );
+        }
+
+        @DisplayName("null 또는 빈 리스트를 추가하면 예외가 발생한다.")
+        @ParameterizedTest
+        @NullAndEmptySource
+        void failWhenInvalidList(List<CartItem> input) {
+            // given & when
+            Cart cart = Cart.create(new User());
+
+            // then
+            assertThrows(IllegalArgumentException.class, () -> cart.addItem(input));
+        }
+
+        @DisplayName("null 아이템이 포함되어 있으면 예외가 발생한다.")
+        @Test
+        void failWhenItemIsNull() {
+            // given
+            Cart cart = Cart.create(new User());
+            CartItem item = null;
+
+            // when & then
+            assertThrows(NullPointerException.class, () -> cart.addItem(List.of(item)));
+        }
+    }
+
+}

--- a/apps/commerce-api/src/test/java/com/loopers/domain/cart/CartTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/cart/CartTest.java
@@ -3,6 +3,7 @@ package com.loopers.domain.cart;
 import com.loopers.domain.brand.Brand;
 import com.loopers.domain.product.Product;
 import com.loopers.domain.user.User;
+import com.loopers.support.TestFixture;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -15,6 +16,8 @@ import static org.junit.jupiter.api.Assertions.*;
 
 class CartTest {
 
+    User dummyUser = TestFixture.createUser();
+
     @DisplayName("create()")
     @Nested
     class CreateCart {
@@ -22,16 +25,13 @@ class CartTest {
         @DisplayName("사용자 정보가 있으면 장바구니 생성에 성공한다.")
         @Test
         void success() {
-            // given
-            User user = new User();
-
             // when
-            Cart cart = Cart.create(user);
+            Cart cart = Cart.create(dummyUser);
 
             // then
             assertNotNull(cart);
             assertNotNull(cart.getId());
-            assertEquals(user, cart.getUser());
+            assertEquals(dummyUser, cart.getUser());
         }
 
         @DisplayName("사용자 정보가 null이면 예외가 발생한다.")
@@ -46,7 +46,7 @@ class CartTest {
     @Nested
     class AddItem {
 
-        Brand dummyBrand = new Brand();
+        Brand dummyBrand = TestFixture.createBrand();
         Product product = Product.create(
                 dummyBrand,
                 "상품명",
@@ -60,7 +60,7 @@ class CartTest {
         @Test
         void success() {
             // given
-            Cart cart = Cart.create(new User());
+            Cart cart = Cart.create(dummyUser);
             CartItem item1 = CartItem.create(product, 2, 1000);
             CartItem item2 = CartItem.create(product, 1, 2000);
 
@@ -79,7 +79,7 @@ class CartTest {
         @NullAndEmptySource
         void failWhenInvalidList(List<CartItem> input) {
             // given & when
-            Cart cart = Cart.create(new User());
+            Cart cart = Cart.create(dummyUser);
 
             // then
             assertThrows(IllegalArgumentException.class, () -> cart.addItem(input));
@@ -89,7 +89,7 @@ class CartTest {
         @Test
         void failWhenItemIsNull() {
             // given
-            Cart cart = Cart.create(new User());
+            Cart cart = Cart.create(dummyUser);
             CartItem item = null;
 
             // when & then

--- a/apps/commerce-api/src/test/java/com/loopers/domain/like/LikeServiceIntegrationTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/like/LikeServiceIntegrationTest.java
@@ -1,0 +1,301 @@
+package com.loopers.domain.like;
+
+import com.loopers.domain.brand.Brand;
+import com.loopers.domain.brand.BrandRepository;
+import com.loopers.domain.product.Product;
+import com.loopers.domain.product.ProductRepository;
+import com.loopers.domain.user.Gender;
+import com.loopers.domain.user.User;
+import com.loopers.domain.user.UserRepository;
+import com.loopers.utils.DatabaseCleanUp;
+import org.junit.jupiter.api.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.IntStream;
+
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@SpringBootTest
+class LikeServiceIntegrationTest {
+
+    @Autowired
+    private LikeService likeService;
+
+    @Autowired
+    private LikeRepository likeRepository;
+
+    @Autowired
+    private BrandRepository brandRepository;
+
+    @Autowired
+    private ProductRepository productRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private DatabaseCleanUp databaseCleanUp;
+
+    private List<Product> testProductList;
+
+    @BeforeEach
+    void setUp() {
+        // 상품 생성
+        Brand testBrand = brandRepository.save(Brand.create(
+                "브랜드명",
+                "브랜드설명",
+                "https://example.com/brand-image.jpg"
+        ));
+
+        List<Product> products = IntStream.rangeClosed(1, 4)
+                .mapToObj(i -> Product.create(
+                        testBrand,
+                        "상품" + i,
+                        "상품설명",
+                        "https://example.com/product-image.jpg",
+                        i * 1000,
+                        10
+                ))
+                .toList();
+
+        testProductList = productRepository.saveAll(products);
+
+        // 유저 생성
+        User user1 = userRepository.save(User.create("user1", Gender.F, "1999-08-21", "loopers@gmail.com"));
+        User user2 = userRepository.save(User.create("user2", Gender.M, "1999-08-21", "loopers@gmail.com"));
+        User user3 = userRepository.save(User.create("user3", Gender.F, "1999-08-21", "loopers@gmail.com"));
+
+        // product1,2는 좋아요 등록 O, product3,4는 좋아요 등록 X
+        likeRepository.save(Like.create(user1, testProductList.get(0)));
+        likeRepository.save(Like.create(user1, testProductList.get(1)));
+        likeRepository.save(Like.create(user2, testProductList.get(0)));
+    }
+
+    @AfterEach
+    void cleanDatabase() {
+        databaseCleanUp.truncateAllTables();
+    }
+
+    @DisplayName("상품별 좋아요 수 조회 시,")
+    @Nested
+    class getLikeCounts {
+
+        @DisplayName("상품 ID 목록이 비어있다면 빈 맵을 반환한다.")
+        @Test
+        void returnsEmptyMap_whenProductIdsIsEmpty() {
+            // given
+            List<Long> productIds = List.of();
+
+            // when
+            Map<Long, Long> result = likeService.getLikeCounts(productIds);
+
+            // then
+            assertThat(result).isEmpty();
+        }
+
+        @DisplayName("해당 상품에 좋아요가 없다면 0을 반환한다.")
+        @Test
+        void returnsZero_whenProductHasNoLikes() {
+            // given
+            List<Long> productIds = List.of(3L, 4L);
+
+            // when
+            Map<Long, Long> result = likeService.getLikeCounts(productIds);
+
+            // then
+            assertAll(
+                () -> assertThat(result).hasSize(2),
+                () -> assertThat(result.get(3L)).isEqualTo(0L),
+                () -> assertThat(result.get(4L)).isEqualTo(0L)
+            );
+        }
+
+        @DisplayName("해당 상품에 좋아요가 있다면 좋아요 수를 반환한다.")
+        @Test
+        void returnLikeCount_whenLikesExist() {
+            // given
+            List<Long> productIds = testProductList.stream().map(Product::getId).toList();
+
+            // when
+            Map<Long, Long> result = likeService.getLikeCounts(productIds);
+
+            // then
+            assertAll(
+                () -> assertThat(result).hasSize(4),
+                () -> assertThat(result.get(1L)).isGreaterThan(0L),
+                () -> assertThat(result.get(2L)).isGreaterThan(0L),
+                () -> assertThat(result.get(3L)).isEqualTo(0L),
+                () -> assertThat(result.get(4L)).isEqualTo(0L)
+            );
+        }
+    }
+
+
+    @DisplayName("단일 상품 좋아요 수 조회 시,")
+    @Nested
+    class getLikeCount {
+
+        @DisplayName("해당 상품이 존재하면 좋아요 수를 반환한다.")
+        @Test
+        void returnLikeCount_whenProductExist() {
+            // given
+            Long productId = testProductList.get(0).getId();
+
+            // when
+            Long likeCount = likeService.getLikeCount(productId);
+
+            // then
+            assertThat(likeCount).isGreaterThan(0L);
+            assertThat(likeCount).isEqualTo(2L);
+        }
+
+        @DisplayName("해당 상품이 존재하지 않으면 0을 반환한다.")
+        @Test
+        void returnZero_whenProductIsNotExist() {
+            // given
+            Long nonExistingProductId = 999L; // 존재하지 않는 상품 ID
+
+            // when
+            Long likeCount = likeService.getLikeCount(nonExistingProductId);
+
+            // then
+            assertThat(likeCount).isEqualTo(0L);
+        }
+    }
+
+
+    @DisplayName("좋아요 등록 시,")
+    @Nested
+    @Transactional
+    class like {
+
+        @DisplayName("좋아요가 없는 상품이라면 새로 등록한다.")
+        @Test
+        void createNewLike_whenNotLikedBefore() {
+            // given
+            Product product = testProductList.get(2); // 좋아요가 등록되지 않은 상품
+            Optional<User> user = userRepository.findByUserId("user1");
+
+            // when
+            Like savedLike = likeService.like(product, user.get());
+
+            // then
+            assertAll(
+                    () -> assertThat(savedLike).isNotNull(),
+                    () -> assertThat(savedLike.getProduct().getId()).isEqualTo(product.getId()),
+                    () -> assertThat(savedLike.getUser().getUserId()).isEqualTo(user.get().getUserId()),
+                    () -> assertThat(savedLike.getLikedYn()).isEqualTo(LikeStatus.Y)
+            );
+        }
+
+        @DisplayName("이미 좋아요한 상품이면 상태를 Y로 유지한다.")
+        @Test
+        void maintainsLike_whenAlreadyLiked() {
+            // given
+            Product product = testProductList.get(0); // 이미 좋아요가 등록된 상품
+            Optional<User> user = userRepository.findByUserId("user1");
+
+            // when
+            Like savedLike = likeService.like(product, user.get());
+
+            // then
+            assertAll(
+                    () -> assertThat(savedLike).isNotNull(),
+                    () -> assertThat(savedLike.getProduct().getId()).isEqualTo(product.getId()),
+                    () -> assertThat(savedLike.getUser().getUserId()).isEqualTo(user.get().getUserId()),
+                    () -> assertThat(savedLike.getLikedYn()).isEqualTo(LikeStatus.Y)
+            );
+        }
+    }
+
+
+    @DisplayName("좋아요 취소 시,")
+    @Nested
+    @Transactional
+    class unLike {
+
+        @DisplayName("좋아요가 등록된 상품이면 좋아요를 취소한다.")
+        @Test
+        void setLikeStatusToN_whenAlreadyLikedProduct() {
+            // given
+            Product product = testProductList.get(0); // 좋아요가 등록된 상품
+            Optional<User> user = userRepository.findByUserId("user1");
+
+            // when
+            Like savedLike = likeService.unLike(product, user.get());
+
+            // then
+            assertAll(
+                    () -> assertThat(savedLike).isNotNull(),
+                    () -> assertThat(savedLike.getProduct().getId()).isEqualTo(product.getId()),
+                    () -> assertThat(savedLike.getUser().getUserId()).isEqualTo(user.get().getUserId()),
+                    () -> assertThat(savedLike.getLikedYn()).isEqualTo(LikeStatus.N)
+            );
+        }
+
+        @DisplayName("좋아요가 없는 상품을 취소하면 예외가 발생한다.")
+        @Test
+        void throwsIllegalArgumentException_whenUnLikeNonLikedProduct() {
+            // given
+            Product product = testProductList.get(2); // 좋아요가 등록되지 않은 상품
+            Optional<User> user = userRepository.findByUserId("user1");
+
+            // when & then
+            assertThrows(IllegalArgumentException.class, () -> {
+                likeService.unLike(product, user.get());
+            });
+        }
+    }
+
+
+    @DisplayName("좋아요 한 상품 목록 조회 시,")
+    @Nested
+    class getLikeProducts {
+
+        @DisplayName("해당 유저가 좋아요한 상품 목록을 반환한다.")
+        @Test
+        @Transactional
+        void returnLikeProductList() {
+            // given
+            Optional<User> user = userRepository.findByUserId("user1");
+
+            // when
+            List<Like> likeProducts = likeService.getLikeProducts(user.get());
+
+            // then
+            assertAll(
+                    () -> assertThat(likeProducts).isNotEmpty(),
+                    () -> assertThat(likeProducts.size()).isEqualTo(2),
+                    () -> assertThat(likeProducts.get(0).getUser().getUserId()).isEqualTo(user.get().getUserId()),
+                    () -> assertThat(likeProducts.get(0).getLikedYn()).isEqualTo(LikeStatus.Y),
+                    () -> assertThat(likeProducts.get(1).getUser().getUserId()).isEqualTo(user.get().getUserId()),
+                    () -> assertThat(likeProducts.get(1).getLikedYn()).isEqualTo(LikeStatus.Y)
+            );
+        }
+
+        @DisplayName("해당 유저가 좋아요한 상품이 없는 경우, 빈 리스트를 반환한다.")
+        @Test
+        void returnEmptyList_whenUserHasNoLikes() {
+            // given
+            Optional<User> user = userRepository.findByUserId("user3");
+
+            // when
+            List<Like> likeProducts = likeService.getLikeProducts(user.get());
+
+            // then
+            assertAll(
+                    () -> assertThat(likeProducts).isNotNull(),
+                    () -> assertThat(likeProducts).isEmpty()
+            );
+        }
+    }
+
+}

--- a/apps/commerce-api/src/test/java/com/loopers/domain/like/LikeTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/like/LikeTest.java
@@ -2,22 +2,21 @@ package com.loopers.domain.like;
 
 import com.loopers.domain.product.Product;
 import com.loopers.domain.user.User;
+import com.loopers.support.TestFixture;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 class LikeTest {
 
+    User user = TestFixture.createUser();
+    Product product = TestFixture.createProduct(TestFixture.createBrand());
+
     @DisplayName("Like 생성 시 likedYn은 Y 상태이다.")
     @Test
     void createLike() {
-        // given
-        User user = new User();
-        Product product = new Product();
-
         // when
         Like like = Like.create(user, product);
 
@@ -57,39 +56,6 @@ class LikeTest {
         assertThat(like.getLikedYn()).isEqualTo(LikeStatus.N);
     }
 
-    @DisplayName("likeOrCreate - 기존 Like가 있으면 상태만 Y로 바꾼다.")
-    @Test
-    void likeOrCreate_whenExistingLike() {
-        // given
-        Like existing = new Like();
-        existing.unLike();
-
-        // when
-        Like result = Like.likeOrCreate(Optional.of(existing), null, null);
-
-        // then
-        assertThat(result).isSameAs(existing); // 기존 객체와 동일한지 확인
-        assertThat(result.isLiked()).isTrue();
-        assertThat(result.getLikedYn()).isEqualTo(LikeStatus.Y);
-    }
-
-    @DisplayName("likeOrCreate - 기존 Like가 없으면 새 Like를 생성한다.")
-    @Test
-    void likeOrCreate_whenNoLike() {
-        // given
-        User user = new User();
-        Product product = new Product();
-
-        // when
-        Like result = Like.likeOrCreate(Optional.empty(), user, product);
-
-        // then
-        assertThat(result.getUser()).isEqualTo(user);
-        assertThat(result.getProduct()).isEqualTo(product);
-        assertThat(result.isLiked()).isTrue();
-        assertThat(result.getLikedYn()).isEqualTo(LikeStatus.Y);
-    }
-
     @DisplayName("like()가 여러 번 호출되어도 상태는 Y로 유지된다.")
     @Test
     void like_isIdempotent() {
@@ -121,6 +87,5 @@ class LikeTest {
         assertThat(like.isLiked()).isFalse();
         assertThat(like.getLikedYn()).isEqualTo(LikeStatus.N);
     }
-
 
 }

--- a/apps/commerce-api/src/test/java/com/loopers/domain/like/LikeTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/like/LikeTest.java
@@ -1,0 +1,126 @@
+package com.loopers.domain.like;
+
+import com.loopers.domain.product.Product;
+import com.loopers.domain.user.User;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class LikeTest {
+
+    @DisplayName("Like 생성 시 likedYn은 Y 상태이다.")
+    @Test
+    void createLike() {
+        // given
+        User user = new User();
+        Product product = new Product();
+
+        // when
+        Like like = Like.create(user, product);
+
+        // then
+        assertThat(like.getUser()).isEqualTo(user);
+        assertThat(like.getProduct()).isEqualTo(product);
+        assertThat(like.getLikedYn()).isEqualTo(LikeStatus.Y);
+    }
+
+    @DisplayName("like() 호출 시 상태가 Y로 변경된다.")
+    @Test
+    void like_shouldSetStatusToY() {
+        // given
+        Like like = new Like();
+        like.unLike();
+
+        // when
+        like.like();
+
+        // then
+        assertThat(like.isLiked()).isTrue();
+        assertThat(like.getLikedYn()).isEqualTo(LikeStatus.Y);
+    }
+
+    @DisplayName("unLike() 호출 시 상태가 N으로 변경된다.")
+    @Test
+    void unLike_shouldSetStatusToN() {
+        // given
+        Like like = new Like();
+        like.like();
+
+        // when
+        like.unLike();
+
+        // then
+        assertThat(like.isLiked()).isFalse();
+        assertThat(like.getLikedYn()).isEqualTo(LikeStatus.N);
+    }
+
+    @DisplayName("likeOrCreate - 기존 Like가 있으면 상태만 Y로 바꾼다.")
+    @Test
+    void likeOrCreate_whenExistingLike() {
+        // given
+        Like existing = new Like();
+        existing.unLike();
+
+        // when
+        Like result = Like.likeOrCreate(Optional.of(existing), null, null);
+
+        // then
+        assertThat(result).isSameAs(existing); // 기존 객체와 동일한지 확인
+        assertThat(result.isLiked()).isTrue();
+        assertThat(result.getLikedYn()).isEqualTo(LikeStatus.Y);
+    }
+
+    @DisplayName("likeOrCreate - 기존 Like가 없으면 새 Like를 생성한다.")
+    @Test
+    void likeOrCreate_whenNoLike() {
+        // given
+        User user = new User();
+        Product product = new Product();
+
+        // when
+        Like result = Like.likeOrCreate(Optional.empty(), user, product);
+
+        // then
+        assertThat(result.getUser()).isEqualTo(user);
+        assertThat(result.getProduct()).isEqualTo(product);
+        assertThat(result.isLiked()).isTrue();
+        assertThat(result.getLikedYn()).isEqualTo(LikeStatus.Y);
+    }
+
+    @DisplayName("like()가 여러 번 호출되어도 상태는 Y로 유지된다.")
+    @Test
+    void like_isIdempotent() {
+        // given
+        Like like = new Like();
+        like.like();
+
+        // when
+        like.like();
+        like.like();
+
+        // then
+        assertThat(like.isLiked()).isTrue();
+        assertThat(like.getLikedYn()).isEqualTo(LikeStatus.Y);
+    }
+
+    @DisplayName("unLike()가 여러 번 호출되어도 상태는 N로 유지된다.")
+    @Test
+    void unLike_isIdempotent() {
+        // given
+        Like like = new Like();
+        like.unLike();
+
+        // when
+        like.unLike();
+        like.unLike();
+
+        // then
+        assertThat(like.isLiked()).isFalse();
+        assertThat(like.getLikedYn()).isEqualTo(LikeStatus.N);
+    }
+
+
+}

--- a/apps/commerce-api/src/test/java/com/loopers/domain/order/OrderItemTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/order/OrderItemTest.java
@@ -2,6 +2,7 @@ package com.loopers.domain.order;
 
 import com.loopers.domain.brand.Brand;
 import com.loopers.domain.product.Product;
+import com.loopers.support.TestFixture;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -16,7 +17,7 @@ class OrderItemTest {
     @Nested
     class CreateOrderItem {
 
-        Brand dummyBrand = new Brand();
+        Brand dummyBrand = TestFixture.createBrand();
 
         @DisplayName("성공한다.")
         @Test

--- a/apps/commerce-api/src/test/java/com/loopers/domain/order/OrderItemTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/order/OrderItemTest.java
@@ -1,0 +1,104 @@
+package com.loopers.domain.order;
+
+import com.loopers.domain.brand.Brand;
+import com.loopers.domain.product.Product;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class OrderItemTest {
+
+    @DisplayName("OrderItem 생성 시,")
+    @Nested
+    class CreateOrderItem {
+
+        Brand dummyBrand = new Brand();
+
+        @DisplayName("성공한다.")
+        @Test
+        void success_createOrderItem() {
+            // given
+            Product product = Product.create(
+                    dummyBrand,
+                    "상품명",
+                    "상품설명",
+                    "https://example.com/image.jpg",
+                    1000,
+                    10
+            );
+            int quantity = 2;
+            int price = 2000;
+
+            // when
+            OrderItem orderItem = OrderItem.create(product, quantity, price);
+
+            // then
+            assertAll(
+                    () -> assertEquals(product, orderItem.getProduct()),
+                    () -> assertEquals(quantity, orderItem.getQuantity()),
+                    () -> assertEquals(price, orderItem.getPrice())
+            );
+        }
+
+        @DisplayName("상품 수량이 0 이하이면 예외가 발생한다.")
+        @ParameterizedTest
+        @ValueSource(ints = {
+                0,
+                -1,
+                -100
+        })
+        void throwsIllegalArgumentException_whenQuantityIsNegative(int quantity) {
+            // given
+            Product product = Product.create(
+                    dummyBrand,
+                    "상품명",
+                    "상품설명",
+                    "https://example.com/image.jpg",
+                    1000,
+                    10
+            );
+
+            // when & then
+            assertThrows(IllegalArgumentException.class, () ->
+                    OrderItem.create(product, quantity, 1000)
+            );
+        }
+
+        @DisplayName("가격이 0 이하이면 예외가 발생한다.")
+        @ParameterizedTest
+        @ValueSource(ints = {
+                0,
+                -1,
+                -100
+        })
+        void throwsIllegalArgumentException_whenPriceIsNegative(int price) {
+            // given
+            Product product = Product.create(
+                    dummyBrand,
+                    "상품명",
+                    "상품설명",
+                    "https://example.com/image.jpg",
+                    1000,
+                    10
+            );
+
+            // when & then
+            assertThrows(IllegalArgumentException.class, () ->
+                    OrderItem.create(product, 1, price)
+            );
+        }
+
+        @DisplayName("상품이 null이면 예외가 발생한다.")
+        @Test
+        void throwsNullPointerException_whenProductIsNull() {
+            assertThrows(NullPointerException.class, () ->
+                    OrderItem.create(null, 1, 1000)
+            );
+        }
+    }
+
+}

--- a/apps/commerce-api/src/test/java/com/loopers/domain/order/OrderServiceIntegrationTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/order/OrderServiceIntegrationTest.java
@@ -1,0 +1,276 @@
+package com.loopers.domain.order;
+
+import com.loopers.application.order.OrderItemCommand;
+import com.loopers.domain.brand.Brand;
+import com.loopers.domain.brand.BrandRepository;
+import com.loopers.domain.point.Point;
+import com.loopers.domain.point.PointRepository;
+import com.loopers.domain.product.Product;
+import com.loopers.domain.product.ProductRepository;
+import com.loopers.domain.user.User;
+import com.loopers.domain.user.UserRepository;
+import com.loopers.utils.DatabaseCleanUp;
+import org.junit.jupiter.api.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@SpringBootTest
+class OrderServiceIntegrationTest {
+
+    @Autowired
+    private OrderService orderService;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private BrandRepository brandRepository;
+
+    @Autowired
+    private ProductRepository productRepository;
+
+    @Autowired
+    private PointRepository pointRepository;
+
+    @Autowired
+    private DatabaseCleanUp databaseCleanUp;
+
+    private User savedUser;
+
+    private Brand savedBrand;
+
+    @BeforeEach
+    void setUp() {
+        User user = new User();
+        savedUser = userRepository.save(user);
+
+        Brand brand = new Brand();
+        savedBrand = brandRepository.save(brand);
+    }
+
+    @AfterEach
+    void cleanDatabase() {
+        databaseCleanUp.truncateAllTables();
+    }
+
+    @DisplayName("주문 생성 시,")
+    @Nested
+    class createOrder {
+
+        @DisplayName("정상적으로 주문이 생성되고 재고 및 포인트가 차감된다.")
+        @Test
+        void createOrder_success() {
+            // given
+            Product product = Product.create(
+                    savedBrand,
+                    "상품명",
+                    "상품설명",
+                    "https://example.com/image.jpg",
+                    10000,
+                    10
+            );
+            Product savedProduct = productRepository.save(product);
+
+            Point point = Point.create(savedUser);
+            point.charge(50000);
+            Point savedPoint = pointRepository.save(point);
+
+            OrderItemCommand command = new OrderItemCommand(savedProduct.getId(), 2, 10000);
+            List<OrderItemCommand> commands = List.of(command);
+
+            // when
+            Order order = orderService.createOrder(commands, savedUser, savedPoint, List.of(savedProduct));
+
+            // then
+            assertAll(
+                    () -> assertThat(order.getOrderItems()).hasSize(1),
+                    () -> assertThat(order.getTotalPrice()).isEqualTo(20000),
+                    () -> assertThat(order.getStatus()).isEqualTo(OrderStatus.PAID),
+                    () -> assertThat(savedProduct.getStock()).isEqualTo(8),
+                    () -> assertThat(savedPoint.getBalance()).isEqualTo(30000)
+            );
+        }
+
+        @DisplayName("재고가 부족하면 예외가 발생한다.")
+        @Test
+        void createOrder_fail_dueToInsufficientStock() {
+            // given
+            Product product = Product.create(
+                    savedBrand,
+                    "상품명",
+                    "상품설명",
+                    "https://example.com/image.jpg",
+                    10000,
+                    1
+            );
+            Product savedProduct = productRepository.save(product);
+
+            Point point = Point.create(savedUser);
+            point.charge(50000);
+            Point savedPoint = pointRepository.save(point);
+
+            OrderItemCommand command = new OrderItemCommand(savedProduct.getId(), 2, 10000);
+            List<OrderItemCommand> commands = List.of(command);
+
+            // when & then
+            assertThrows(IllegalStateException.class, () -> {
+                orderService.createOrder(commands, savedUser, savedPoint, List.of(savedProduct));
+            });
+        }
+
+        @DisplayName("포인트가 부족하면 예외가 발생한다.")
+        @Test
+        void createOrder_fail_dueToInsufficientPoint() {
+            // given
+            Product product = Product.create(
+                    savedBrand,
+                    "상품명",
+                    "상품설명",
+                    "https://example.com/image.jpg",
+                    10000,
+                    10
+            );
+            Product savedProduct = productRepository.save(product);
+
+            Point point = Point.create(savedUser);
+            point.charge(20000);
+            Point savedPoint = pointRepository.save(point);
+
+            OrderItemCommand command = new OrderItemCommand(savedProduct.getId(), 5, 10000);
+            List<OrderItemCommand> commands = List.of(command);
+
+            // when & then
+            assertThrows(IllegalStateException.class, () -> {
+                orderService.createOrder(commands, savedUser, savedPoint, List.of(savedProduct));
+            });
+        }
+
+    }
+
+    @DisplayName("주문 목록 조회 시,")
+    @Nested
+    class getOrders {
+
+        @DisplayName("주문 목록을 정상적으로 조회한다.")
+        @Test
+        void success() {
+            // given
+            Product product = Product.create(
+                    savedBrand,
+                    "상품명",
+                    "상품설명",
+                    "https://example.com/image.jpg",
+                    10000,
+                    10
+            );
+            Product savedProduct = productRepository.save(product);
+
+            Point point = Point.create(savedUser);
+            point.charge(20000);
+            Point savedPoint = pointRepository.save(point);
+
+            OrderItemCommand command = new OrderItemCommand(savedProduct.getId(), 1, 10000);
+            orderService.createOrder(List.of(command), savedUser, savedPoint, List.of(savedProduct));
+
+            // when
+            List<Order> orders = orderService.getOrders(savedUser);
+
+            // then
+            assertThat(orders).isNotEmpty();
+            assertThat(orders.get(0).getUser().getId()).isEqualTo(savedUser.getId());
+        }
+
+        @DisplayName("주문이 없는 경우 빈 목록을 반환한다.")
+        @Test
+        void emptyOrders() {
+            // when
+            List<Order> orders = orderService.getOrders(savedUser);
+
+            // then
+            assertThat(orders).isEmpty();
+        }
+
+    }
+
+    @DisplayName("주문 상세 조회 시,")
+    @Nested
+    class getOrderDetails {
+
+        @DisplayName("주문 상세를 정상적으로 조회한다.")
+        @Test
+        void success() {
+            // given
+            Product product = Product.create(
+                    savedBrand,
+                    "상품명",
+                    "상품설명",
+                    "https://example.com/image.jpg",
+                    10000,
+                    10
+            );
+            Product savedProduct = productRepository.save(product);
+
+            Point point = Point.create(savedUser);
+            point.charge(20000);
+            Point savedPoint = pointRepository.save(point);
+
+            OrderItemCommand command = new OrderItemCommand(savedProduct.getId(), 1, 10000);
+            Order order = orderService.createOrder(List.of(command), savedUser, savedPoint, List.of(savedProduct));
+
+            // when
+            Order found = orderService.getOrderDetail(order.getId(), savedUser);
+
+            // then
+            assertThat(found.getId()).isEqualTo(order.getId());
+        }
+
+        @DisplayName("존재하지 않는 주문 ID로 조회하면 null을 반환한다.")
+        @Test
+        void orderNotFound() {
+            // when
+            Order found = orderService.getOrderDetail(-1L, savedUser);
+
+            // then
+            assertThat(found).isNull();
+        }
+
+        @DisplayName("다른 유저의 주문을 조회하면 null을 반환한다.")
+        @Test
+        void wrongUser() {
+            // given
+            User savedUser2 = userRepository.save(new User());
+
+            Product product = Product.create(
+                    savedBrand,
+                    "상품명",
+                    "상품설명",
+                    "https://example.com/image.jpg",
+                    10000,
+                    10
+            );
+            Product savedProduct = productRepository.save(product);
+
+            Point point = Point.create(savedUser);
+            point.charge(20000);
+            Point savedPoint = pointRepository.save(point);
+
+            OrderItemCommand command = new OrderItemCommand(savedProduct.getId(), 1, 10000);
+            Order order = orderService.createOrder(List.of(command), savedUser, savedPoint, List.of(savedProduct));
+
+            // when
+            Order found = orderService.getOrderDetail(order.getId(), savedUser2);
+
+            // then
+            assertThat(found).isNull();
+        }
+
+    }
+
+}

--- a/apps/commerce-api/src/test/java/com/loopers/domain/order/OrderTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/order/OrderTest.java
@@ -2,6 +2,7 @@ package com.loopers.domain.order;
 
 import com.loopers.domain.product.Product;
 import com.loopers.domain.user.User;
+import com.loopers.support.TestFixture;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -12,6 +13,9 @@ import static org.junit.jupiter.api.Assertions.*;
 
 class OrderTest {
 
+    User user = TestFixture.createUser();
+    Product product = TestFixture.createProduct(TestFixture.createBrand());
+
     @DisplayName("place()")
     @Nested
     class placeOrder {
@@ -20,8 +24,6 @@ class OrderTest {
         @Test
         void success() {
             // given
-            User user = new User();
-            Product product = new Product();
             OrderItem item1 = OrderItem.create(product, 1, 1000);
             OrderItem item2 = OrderItem.create(product, 1, 2000);
 
@@ -41,9 +43,6 @@ class OrderTest {
         @DisplayName("주문 아이템이 null이면 예외가 발생한다.")
         @Test
         void throwsException_whenItemsNull() {
-            // given
-            User user = new User();
-
             // when & then
             assertThrows(IllegalArgumentException.class, () -> Order.place(user, null));
         }
@@ -52,7 +51,6 @@ class OrderTest {
         @Test
         void throwsException_whenUserIsNull() {
             // given
-            Product product = new Product();
             OrderItem item = OrderItem.create(product, 1, 1000);
 
             // when & then
@@ -62,9 +60,6 @@ class OrderTest {
         @DisplayName("주문 아이템이 빈 리스트이면 예외가 발생한다.")
         @Test
         void throwsException_whenItemsEmpty() {
-            // given
-            User user = new User();
-
             // when & then
             assertThrows(IllegalArgumentException.class, () -> Order.place(user, List.of()));
         }
@@ -80,7 +75,6 @@ class OrderTest {
         void success() {
             // given
             Order order = new Order();
-            Product product = new Product();
             OrderItem item = OrderItem.create(product, 1, 1500);
 
             // when
@@ -113,7 +107,6 @@ class OrderTest {
         void success() {
             // given
             Order order = new Order();
-            Product product = new Product();
             OrderItem item1 = OrderItem.create(product, 1, 1000);
             OrderItem item2 = OrderItem.create(product, 1, 2000);
             order.addItem(item1);

--- a/apps/commerce-api/src/test/java/com/loopers/domain/order/OrderTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/order/OrderTest.java
@@ -1,0 +1,170 @@
+package com.loopers.domain.order;
+
+import com.loopers.domain.product.Product;
+import com.loopers.domain.user.User;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class OrderTest {
+
+    @DisplayName("place()")
+    @Nested
+    class placeOrder {
+
+        @DisplayName("정상 주문 생성에 성공한다.")
+        @Test
+        void success() {
+            // given
+            User user = new User();
+            Product product = new Product();
+            OrderItem item1 = OrderItem.create(product, 1, 1000);
+            OrderItem item2 = OrderItem.create(product, 1, 2000);
+
+            // when
+            Order order = Order.place(user, List.of(item1, item2));
+
+            // then
+            assertAll(
+                    () -> assertEquals(user, order.getUser()),
+                    () -> assertEquals(2, order.getOrderItems().size()),
+                    () -> assertEquals(3000, order.getTotalPrice()),
+                    () -> assertEquals(OrderStatus.PLACED, order.getStatus()),
+                    () -> assertNotNull(order.getPaidAt())
+            );
+        }
+
+        @DisplayName("주문 아이템이 null이면 예외가 발생한다.")
+        @Test
+        void throwsException_whenItemsNull() {
+            // given
+            User user = new User();
+
+            // when & then
+            assertThrows(IllegalArgumentException.class, () -> Order.place(user, null));
+        }
+
+        @DisplayName("주문 사용자(User)가 null이면 예외가 발생한다.")
+        @Test
+        void throwsException_whenUserIsNull() {
+            // given
+            Product product = new Product();
+            OrderItem item = OrderItem.create(product, 1, 1000);
+
+            // when & then
+            assertThrows(NullPointerException.class, () -> Order.place(null, List.of(item)));
+        }
+
+        @DisplayName("주문 아이템이 빈 리스트이면 예외가 발생한다.")
+        @Test
+        void throwsException_whenItemsEmpty() {
+            // given
+            User user = new User();
+
+            // when & then
+            assertThrows(IllegalArgumentException.class, () -> Order.place(user, List.of()));
+        }
+    }
+
+
+    @DisplayName("addItem()")
+    @Nested
+    class AddItem {
+
+        @DisplayName("아이템을 정상적으로 추가한다.")
+        @Test
+        void success() {
+            // given
+            Order order = new Order();
+            Product product = new Product();
+            OrderItem item = OrderItem.create(product, 1, 1500);
+
+            // when
+            order.addItem(item);
+
+            // then
+            assertEquals(1, order.getOrderItems().size());
+            assertEquals(item, order.getOrderItems().get(0));
+        }
+
+        @DisplayName("아이템이 null이면 예외가 발생한다.")
+        @Test
+        void throwsException_whenItemIsNull() {
+            // given
+            Order order = new Order();
+
+            // when & then
+            assertThrows(IllegalArgumentException.class, () -> order.addItem(null));
+        }
+
+    }
+
+
+    @DisplayName("calculateTotalPrice()")
+    @Nested
+    class CalculateTotalPrice {
+
+        @DisplayName("주문 아이템들의 가격 합계를 계산한다.")
+        @Test
+        void success() {
+            // given
+            Order order = new Order();
+            Product product = new Product();
+            OrderItem item1 = OrderItem.create(product, 1, 1000);
+            OrderItem item2 = OrderItem.create(product, 1, 2000);
+            order.addItem(item1);
+            order.addItem(item2);
+
+            // when
+            int total = order.calculateTotalPrice();
+
+            // then
+            assertEquals(3000, total);
+        }
+
+        @DisplayName("주문 아이템이 없으면 총합은 0이다.")
+        @Test
+        void returnsZero_whenNoItems() {
+            // given
+            Order order = new Order();
+
+            // when
+            int total = order.calculateTotalPrice();
+
+            // then
+            assertEquals(0, total);
+        }
+    }
+
+
+    @DisplayName("updateOrderStatus()")
+    @Nested
+    class UpdateOrderStatus {
+
+        @DisplayName("주문 상태를 정상적으로 변경한다.")
+        @Test
+        void success() {
+            // given
+            Order order = new Order();
+
+            // when
+            order.updateOrderStatus(OrderStatus.PAID);
+
+            // then
+            assertEquals(OrderStatus.PAID, order.getStatus());
+        }
+
+        @DisplayName("null 상태로 업데이트하면 예외가 발생한다.")
+        @Test
+        void throwsException_whenStatusIsNull() {
+            Order order = new Order();
+
+            assertThrows(IllegalArgumentException.class, () -> order.updateOrderStatus(null));
+        }
+    }
+
+}

--- a/apps/commerce-api/src/test/java/com/loopers/domain/point/PointServiceIntegrationTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/point/PointServiceIntegrationTest.java
@@ -1,0 +1,159 @@
+package com.loopers.domain.point;
+
+import com.loopers.domain.user.Gender;
+import com.loopers.domain.user.User;
+import com.loopers.domain.user.UserRepository;
+import com.loopers.support.TestFixture;
+import com.loopers.utils.DatabaseCleanUp;
+import org.junit.jupiter.api.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@Transactional
+class PointServiceIntegrationTest {
+
+    @Autowired
+    private PointService pointService;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private DatabaseCleanUp databaseCleanUp;
+
+    private User savedUser;
+
+    @BeforeEach
+    void setUp() {
+        User user = TestFixture.createUser();
+        savedUser = userRepository.save(user);
+    }
+
+    @AfterEach
+    void cleanDatabase() {
+        databaseCleanUp.truncateAllTables();
+    }
+
+    @DisplayName("포인트 생성(create)")
+    @Nested
+    class CreatePoint {
+
+        @DisplayName("포인트가 정상적으로 생성된다.")
+        @Test
+        void create_success() {
+            // when
+            Point point = pointService.create(savedUser);
+
+            // then
+            assertAll(
+                    () -> assertThat(point).isNotNull(),
+                    () -> assertThat(point.getUser()).isEqualTo(savedUser),
+                    () -> assertThat(point.getBalance()).isEqualTo(0)
+            );
+        }
+    }
+
+
+    @DisplayName("포인트 충전(charge)")
+    @Nested
+    class ChargePoint {
+
+        @DisplayName("정상적으로 포인트가 충전된다.")
+        @Test
+        void charge_success() {
+            // given: 포인트가 없는 유저에 대해 생성 후 충전
+            pointService.create(savedUser);
+
+            // when
+            Point charged = pointService.charge(savedUser, 5000L);
+
+            // then
+            assertAll(
+                    () -> assertThat(charged).isNotNull(),
+                    () -> assertThat(charged.getBalance()).isEqualTo(5000L)
+            );
+        }
+
+        @DisplayName("존재하지 않는 유저의 포인트 충전 시 예외가 발생한다.")
+        @Test
+        void charge_fail_whenPointNotFound() {
+            // given
+            User user = userRepository.save(User.create("ghost", Gender.F, "2001-01-01", "ghost@example.com"));
+
+            // when & then
+            assertThrows(IllegalArgumentException.class, () -> {
+                pointService.charge(user, 1000L);
+            });
+        }
+    }
+
+    @Nested
+    @DisplayName("포인트 조회(getPoint)")
+    class GetPoint {
+
+        @Test
+        @DisplayName("포인트가 존재하면 정상적으로 조회된다.")
+        void getPoint_success() {
+            // given
+            Point created = pointService.create(savedUser);
+
+            // when
+            Point found = pointService.getPoint(savedUser);
+
+            // then
+            assertThat(found).isNotNull();
+            assertThat(found.getId()).isEqualTo(created.getId());
+            assertThat(found.getUser()).isEqualTo(savedUser);
+        }
+
+        @Test
+        @DisplayName("포인트가 존재하지 않으면 예외가 발생한다.")
+        void getPoint_fail_whenPointNotFound() {
+            // given (user save - x, point - x)
+            User user = userRepository.save(User.create("ghost", Gender.F, "2001-01-01", "ghost@example.com"));
+
+            // when & then
+            assertThrows(IllegalArgumentException.class, () -> {
+                pointService.getPoint(user);
+            });
+        }
+    }
+
+    @Nested
+    @DisplayName("포인트 차감(checkAndUsePoint)")
+    class UsePoint {
+
+        @Test
+        @DisplayName("충분한 포인트가 있을 경우 차감이 정상적으로 이뤄진다.")
+        void usePoint_success() {
+            // given
+            pointService.create(savedUser);
+            pointService.charge(savedUser, 10000L);
+            Point point = pointService.getPoint(savedUser);
+
+            // when
+            Point used = pointService.checkAndUsePoint(point, 4000);
+
+            // then
+            assertThat(used.getBalance()).isEqualTo(6000L);
+        }
+
+        @Test
+        @DisplayName("보유 포인트보다 많은 금액을 사용하려 할 경우 예외가 발생한다.")
+        void usePoint_fail_dueToInsufficientBalance() {
+            // given
+            pointService.create(savedUser);
+            Point point = pointService.getPoint(savedUser);
+
+            // when & then
+            assertThrows(IllegalStateException.class, () -> {
+                pointService.checkAndUsePoint(point, 5000);
+            });
+        }
+    }
+}

--- a/apps/commerce-api/src/test/java/com/loopers/domain/point/PointTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/point/PointTest.java
@@ -1,5 +1,7 @@
 package com.loopers.domain.point;
 
+import com.loopers.domain.user.Gender;
+import com.loopers.domain.user.User;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -21,8 +23,8 @@ class PointTest {
         @ValueSource(longs = {0L, -100L, -1L})
         void throwsIllegalArgumentException_whenChargeAmountIsZeroOrNegative(long amount) {
             // given
-            String userId = "oyy";
-            Point point = Point.create(userId);
+            User user = User.create("oyy", Gender.F, "1999-08-21", "loopers@gmail.com");
+            Point point = Point.create(user);
 
             // when & then
             assertThrows(IllegalArgumentException.class, () -> {

--- a/apps/commerce-api/src/test/java/com/loopers/domain/point/PointTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/point/PointTest.java
@@ -4,6 +4,7 @@ import com.loopers.domain.user.Gender;
 import com.loopers.domain.user.User;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
@@ -30,6 +31,67 @@ class PointTest {
             assertThrows(IllegalArgumentException.class, () -> {
                 point.charge(amount);
             });
+        }
+
+        @DisplayName("양수의 금액으로 포인트를 충전 시 성공한다.")
+        @ParameterizedTest
+        @ValueSource(longs = {1L, 100L, Long.MAX_VALUE})
+        void success_whenChargeAmountIsPositive(long amount) {
+            // given
+            User user = User.create("oyy", Gender.F, "1999-08-21", "loopers@gmail.com");
+            Point point = Point.create(user);
+
+            // when
+            point.charge(amount);
+
+            // then
+            assertEquals(amount, point.getBalance());
+        }
+    }
+
+    @DisplayName("포인트 차감 시,")
+    @Nested
+    class pointUse {
+
+        @DisplayName("보유 포인트 이하의 금액으로 차감 시 성공한다.")
+        @ParameterizedTest
+        @ValueSource(longs = {1L, 100L, 500L})
+        void success_whenUseAmountIsValid(long amount) {
+            // given
+            User user = User.create("oyy", Gender.F, "1999-08-21", "loopers@gmail.com");
+            Point point = Point.create(user);
+            point.charge(1000L);
+
+            // when
+            point.use(amount);
+
+            // then
+            assertEquals(1000L - amount, point.getBalance());
+        }
+
+        @DisplayName("보유 포인트를 초과하여 차감 시 예외가 발생한다.")
+        @Test
+        void throwsException_whenUseAmountExceedsBalance() {
+            // given
+            User user = User.create("oyy", Gender.F, "1999-08-21", "loopers@gmail.com");
+            Point point = Point.create(user);
+            point.charge(1000L);
+
+            // when & then
+            assertThrows(IllegalStateException.class, () -> point.use(2000L));
+        }
+
+        @DisplayName("0 이하의 금액을 차감 시 예외가 발생한다.")
+        @ParameterizedTest
+        @ValueSource(longs = {0L, -1L, -100L})
+        void throwsIllegalArgumentException_whenUseAmountIsZeroOrNegative(long amount) {
+            // given
+            User user = User.create("oyy", Gender.F, "1999-08-21", "loopers@gmail.com");
+            Point point = Point.create(user);
+            point.charge(1000L);
+
+            // when & then
+            assertThrows(IllegalArgumentException.class, () -> point.use(amount));
         }
     }
 

--- a/apps/commerce-api/src/test/java/com/loopers/domain/product/ProductServiceIntegrationTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/product/ProductServiceIntegrationTest.java
@@ -226,4 +226,63 @@ class ProductServiceIntegrationTest {
 
     }
 
+    @DisplayName("상품 ID 목록으로 조회 시,")
+    @Nested
+    class getProductsByIds {
+
+        @Test
+        @DisplayName("존재하는 상품 ID 리스트로 상품들을 정상 조회한다.")
+        void success_whenProductIdsExist() {
+            // given
+            List<Product> savedProducts = productRepository.findByAll().subList(0, 3);
+            List<Long> productIds = savedProducts.stream()
+                    .map(Product::getId)
+                    .toList();
+
+            // when
+            List<Product> foundProducts = productService.getProductsByIds(productIds);
+
+            // then
+            assertThat(foundProducts).hasSize(3);
+            assertThat(foundProducts)
+                    .extracting(Product::getId)
+                    .containsExactlyElementsOf(productIds);
+        }
+
+        @Test
+        @DisplayName("빈 ID 리스트를 전달하면 빈 결과를 반환한다.")
+        void returnEmpty_whenProductIdsIsEmpty() {
+            // given
+            List<Long> productIds = List.of();
+
+            // when
+            List<Product> products = productService.getProductsByIds(productIds);
+
+            // then
+            assertThat(products).isEmpty();
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 상품 ID를 포함해도, 존재하는 상품만 조회된다.")
+        void returnPartial_whenSomeIdsDoNotExist() {
+            // given
+            List<Product> savedProducts = productRepository.findByAll().subList(0, 2);
+            List<Long> productIds = savedProducts.stream()
+                    .map(Product::getId)
+                    .toList();
+
+            List<Long> mixedIds = List.of(productIds.get(0), 999L, productIds.get(1));
+
+            // when
+            List<Product> found = productService.getProductsByIds(mixedIds);
+
+            // then
+            assertThat(found).hasSize(2);
+            assertThat(found)
+                    .extracting(Product::getId)
+                    .containsExactlyInAnyOrderElementsOf(productIds);
+        }
+
+    }
+
 }

--- a/apps/commerce-api/src/test/java/com/loopers/domain/product/ProductServiceIntegrationTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/product/ProductServiceIntegrationTest.java
@@ -1,0 +1,229 @@
+package com.loopers.domain.product;
+
+import com.loopers.application.product.ProductCommand;
+import com.loopers.domain.brand.Brand;
+import com.loopers.domain.brand.BrandRepository;
+import com.loopers.utils.DatabaseCleanUp;
+import org.junit.jupiter.api.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+
+import java.util.List;
+import java.util.stream.IntStream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@SpringBootTest
+class ProductServiceIntegrationTest {
+
+    @Autowired
+    private ProductService productService;
+
+    @Autowired
+    private BrandRepository brandRepository;
+
+    @Autowired
+    private ProductRepository productRepository;
+
+    @Autowired
+    private DatabaseCleanUp databaseCleanUp;
+
+    private Brand testBrand;
+
+    @BeforeEach
+    void setupTestData() {
+        testBrand = brandRepository.save(Brand.create(
+                "브랜드명",
+                "브랜드설명",
+                "https://example.com/brand-image.jpg"
+        ));
+
+        List<Product> products = IntStream.rangeClosed(1, 30)
+                .mapToObj(i -> Product.create(
+                        testBrand,
+                        "상품" + i,
+                        "상품설명",
+                        "https://example.com/product-image.jpg",
+                        i * 1000,
+                        10
+                ))
+                .toList();
+
+        productRepository.saveAll(products);
+    }
+
+    @AfterEach
+    void cleanDatabase() {
+        databaseCleanUp.truncateAllTables();
+    }
+
+    @DisplayName("상품 목록 조회 시,")
+    @Nested
+    class getProducts {
+
+        @DisplayName("상품 목록이 정상적으로 조회된다.")
+        @Test
+        void successToGetProducts() {
+            // given
+            ProductCommand command = new ProductCommand(
+                    testBrand.getId(),
+                    0,
+                    20,
+                    Sort.by(Sort.Direction.ASC, "price")
+            );
+
+            // when
+            Page<Product> products = productService.getProducts(command);
+
+            // then
+            assertThat(products).isNotNull();
+            assertThat(products.getTotalElements()).isEqualTo(30);
+            assertThat(products.getContent()).hasSize(20);
+            assertThat(products.getContent().get(0).getPrice()).isEqualTo(1000);
+        }
+
+        @DisplayName("존재하지 않는 브랜드 ID가 주어지면 빈 목록이 반환된다.")
+        @Test
+        void returnEmpty_whenBrandIdNotExist() {
+            // given
+            Long notExistBrandId = 999L;
+            ProductCommand command = new ProductCommand(
+                    notExistBrandId,
+                    0,
+                    20,
+                    Sort.unsorted()
+            );
+
+            // when
+            Page<Product> products = productService.getProducts(command);
+
+            // then
+            assertThat(products).isNotNull();
+            assertThat(products.getTotalElements()).isEqualTo(0);
+            assertThat(products.getContent()).isEmpty();
+        }
+
+        @DisplayName("정렬 기준이 없을 경우 기본 정렬로 동작한다.")
+        @Test
+        void fallbackToDefaultSort_whenInvalidSortProvided() {
+            // given
+            ProductCommand command = new ProductCommand(
+                    testBrand.getId(),
+                    0,
+                    20,
+                    null
+            );
+
+            // when
+            Page<Product> products = productService.getProducts(command);
+            List<Product> content = products.getContent();
+
+            // then
+            assertThat(products).isNotNull();
+            assertThat(products.getContent()).isNotEmpty();
+            assertThat(content.get(0).getCreatedAt()).isAfterOrEqualTo(content.get(1).getCreatedAt());
+        }
+
+        @DisplayName("page가 음수일 경우 기본값(0)으로 조회된다.")
+        @Test
+        void fallbackToDefaultPage_whenPageIsNegative() {
+            // given
+            ProductCommand command = new ProductCommand(
+                    testBrand.getId(),
+                    -1,
+                    20,
+                    Sort.unsorted()
+            );
+
+            // when
+            Page<Product> products = productService.getProducts(command);
+
+            // then
+            assertThat(products).isNotNull();
+            assertThat(products.getContent()).hasSize(20);
+        }
+
+        @DisplayName("page가 유효한 범위를 초과하면 빈 목록이 반환된다.")
+        @Test
+        void returnEmpty_whenPageOutOfRange() {
+            // given
+            ProductCommand command = new ProductCommand(
+                    testBrand.getId(),
+                    999,
+                    20,
+                    Sort.unsorted()
+            );
+
+            // when
+            Page<Product> products = productService.getProducts(command);
+
+            // then
+            assertThat(products).isNotNull();
+            assertThat(products.getContent()).isEmpty();
+        }
+
+        @DisplayName("size가 0 이하일 경우 기본값(20)으로 조회된다.")
+        @Test
+        void fallbackToDefaultSize_whenSizeIsInvalid() {
+            // given
+            ProductCommand command = new ProductCommand(
+                    testBrand.getId(),
+                    0,
+                    0,
+                    Sort.unsorted()
+            );
+
+            // when
+            Page<Product> products = productService.getProducts(command);
+
+            // then
+            assertThat(products).isNotNull();
+            assertThat(products.getContent()).hasSize(20);
+        }
+    }
+
+    @DisplayName("상품 상세 조회 시,")
+    @Nested
+    class getProductDetail {
+
+        @DisplayName("존재하는 상품 ID로 조회 시, 상품 정보가 반환된다.")
+        @Test
+        void returnsProductDetail_whenProductExists() {
+            // given
+            Pageable pageable = PageRequest.of(0, 1);
+            ProductSearchCondition condition = new ProductSearchCondition(testBrand.getId(), pageable);
+            Product product = productRepository.findByCondition(condition).getContent().get(0);
+
+            // when
+            Product foundProduct = productService.getProductDetail(product.getId());
+
+            // then
+            assertAll(
+                    () -> assertThat(foundProduct).isNotNull(),
+                    () -> assertThat(foundProduct.getId()).isEqualTo(product.getId()),
+                    () -> assertThat(foundProduct.getName()).isEqualTo(product.getName()),
+                    () -> assertThat(foundProduct.getPrice()).isEqualTo(product.getPrice())
+            );
+        }
+
+        @DisplayName("존재하지 않는 상품 ID로 조회 시, 예외가 발생한다.")
+        @Test
+        void throwIllegalArgumentException_whenProductIdIdNotExist() {
+            // given
+            Long notExistProductId = 999L;
+
+            // when & then
+            assertThrows(IllegalArgumentException.class, () -> {
+                productService.getProductDetail(notExistProductId);
+            });
+        }
+
+    }
+
+}

--- a/apps/commerce-api/src/test/java/com/loopers/domain/product/ProductTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/product/ProductTest.java
@@ -1,6 +1,7 @@
 package com.loopers.domain.product;
 
 import com.loopers.domain.brand.Brand;
+import com.loopers.support.TestFixture;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -11,11 +12,11 @@ import static org.junit.jupiter.api.Assertions.*;
 
 class ProductTest {
 
+    Brand dummyBrand = TestFixture.createBrand();
+
     @DisplayName("상품 생성 시,")
     @Nested
     class CreateProduct {
-
-        Brand dummyBrand = new Brand();
 
         @DisplayName("브랜드가 null이면 예외가 발생한다")
         @Test
@@ -53,10 +54,9 @@ class ProductTest {
             );
         }
 
-        @DisplayName("가격이 0 이하이면 예외가 발생한다.")
+        @DisplayName("가격이 음수이면 예외가 발생한다.")
         @ParameterizedTest
         @ValueSource(ints = {
-                0,
                 -1,
                 -100
         })
@@ -136,8 +136,6 @@ class ProductTest {
     @DisplayName("상품 재고 차감 시,")
     @Nested
     class DecreaseStock {
-
-        Brand dummyBrand = new Brand();
 
         @DisplayName("재고가 충분하면 정상적으로 차감된다.")
         @Test

--- a/apps/commerce-api/src/test/java/com/loopers/domain/product/ProductTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/product/ProductTest.java
@@ -1,0 +1,136 @@
+package com.loopers.domain.product;
+
+import com.loopers.domain.brand.Brand;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ProductTest {
+
+    @DisplayName("상품 생성 시,")
+    @Nested
+    class CreateProduct {
+
+        Brand dummyBrand = new Brand();
+
+        @DisplayName("브랜드가 null이면 예외가 발생한다")
+        @Test
+        void throwsException_whenBrandIsNull() {
+            assertThrows(IllegalArgumentException.class, () ->
+                    Product.create(
+                            null,
+                            "상품명",
+                            "상품설명",
+                            "https://example.com/image.jpg",
+                            1000,
+                            10
+                    )
+            );
+        }
+
+        @DisplayName("상품명은 한글 또는 영어, 숫자만 허용되며, 공백이나 특수문자가 포함되면 예외가 발생한다.")
+        @ParameterizedTest
+        @ValueSource(strings = {
+                "",
+                "예시상품@@#",
+                "@#$%^&*()_+",
+                "a12 345$#Q"
+        })
+        void throwsIllegalArgumentException_whenNameIsInvalid(String name) {
+            assertThrows(IllegalArgumentException.class, () ->
+                    Product.create(
+                            dummyBrand,
+                            name,
+                            "상품설명",
+                            "https://example.com/image.jpg",
+                            1000,
+                            10
+                    )
+            );
+        }
+
+        @DisplayName("가격이 0 이하이면 예외가 발생한다.")
+        @ParameterizedTest
+        @ValueSource(ints = {
+                0,
+                -1,
+                -100
+        })
+        void throwsIllegalArgumentException_whenPriceIsNegative(int price) {
+            assertThrows(IllegalArgumentException.class, () ->
+                    Product.create(
+                            dummyBrand,
+                            "상품명",
+                            "상품설명",
+                            "https://example.com/image.jpg",
+                            price,
+                            10
+                    )
+            );
+        }
+
+        @DisplayName("재고가 0 이하이면 예외가 발생한다.")
+        @ParameterizedTest
+        @ValueSource(ints = {
+                0,
+                -1,
+                -100
+        })
+        void throwsIllegalArgumentException_whenStockIsNegative(int stock) {
+            assertThrows(IllegalArgumentException.class, () ->
+                    Product.create(
+                            dummyBrand,
+                            "상품명",
+                            "설명",
+                            "https://example.com/image.jpg",
+                            1000,
+                            stock
+                    )
+            );
+        }
+
+        @DisplayName("imageUrl이 빈 문자열이거나 형식이 올바르지 않으면 예외가 발생한다.")
+        @ParameterizedTest
+        @ValueSource(strings = {
+                "",
+                "  ",
+                "img.jpg",
+                "https://example.com/image",
+                "https://example.com/image.jpggg",
+        })
+        void throwsIllegalArgumentException_whenImageUrlIsInvalid(String imageUrl) {
+            assertThrows(IllegalArgumentException.class, () ->
+                    Product.create(
+                            dummyBrand,
+                            "상품명",
+                            "설명",
+                            imageUrl,
+                            1000,
+                            10
+                    )
+            );
+        }
+
+        @Test
+        @DisplayName("정상적인 값이면 Product가 생성된다.")
+        void success_whenAllValuesAreValid() {
+            Product product = Product.create(
+                    dummyBrand,
+                    "상품명",
+                    "설명",
+                    "https://example.com/image.jpg",
+                    1000,
+                    10
+            );
+
+            assertNotNull(product);
+            assertEquals("상품명", product.getName());
+            assertEquals("ACTIVE", product.getStatus());
+        }
+    }
+
+}

--- a/apps/commerce-api/src/test/java/com/loopers/domain/product/ProductTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/product/ProductTest.java
@@ -133,4 +133,59 @@ class ProductTest {
         }
     }
 
+    @DisplayName("상품 재고 차감 시,")
+    @Nested
+    class DecreaseStock {
+
+        Brand dummyBrand = new Brand();
+
+        @DisplayName("재고가 충분하면 정상적으로 차감된다.")
+        @Test
+        void success_whenStockIsEnough() {
+            Product product = Product.create(
+                    dummyBrand,
+                    "상품명",
+                    "설명",
+                    "https://example.com/image.jpg",
+                    1000,
+                    10
+            );
+
+            product.decreaseStock(3);
+
+            assertEquals(7, product.getStock());
+        }
+
+        @DisplayName("0 이하의 수량을 차감하려 하면 예외가 발생한다.")
+        @ParameterizedTest
+        @ValueSource(ints = {0, -1, -5})
+        void throwsException_whenQuantityIsZeroOrNegative(int quantity) {
+            Product product = Product.create(
+                    dummyBrand,
+                    "상품명",
+                    "설명",
+                    "https://example.com/image.jpg",
+                    1000,
+                    10
+            );
+
+            assertThrows(IllegalArgumentException.class, () -> product.decreaseStock(quantity));
+        }
+
+        @DisplayName("차감할 수량이 현재 재고보다 많으면 예외가 발생한다.")
+        @Test
+        void throwsException_whenStockIsInsufficient() {
+            Product product = Product.create(
+                    dummyBrand,
+                    "상품명",
+                    "설명",
+                    "https://example.com/image.jpg",
+                    1000,
+                    5
+            );
+
+            assertThrows(IllegalStateException.class, () -> product.decreaseStock(10));
+        }
+    }
+
 }

--- a/apps/commerce-api/src/test/java/com/loopers/domain/user/UserServiceIntegrationTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/user/UserServiceIntegrationTest.java
@@ -113,18 +113,16 @@ class UserServiceIntegrationTest {
             );
         }
 
-        @DisplayName("해당 ID 의 회원이 존재하지 않을 경우, null 이 반환된다.")
+        @DisplayName("해당 ID 의 회원이 존재하지 않을 경우, null 이 반환된다.(예외 발생)")
         @Test
         void returnsNull_whenUserDoesNotExist() {
             // given
             String userId = UUID.randomUUID().toString(); // 존재하지 않을만한 ID 생성
 
-            // when
-            User findUser = userService.getMyInfo(userId);
-
-            // then
-            assertThat(findUser).isNull();
-            assertThat(findUser).isEqualTo(null);
+            // when & then
+            assertThrows(NullPointerException.class, () -> {
+                userService.getMyInfo(userId);
+            });
         }
     }
 

--- a/apps/commerce-api/src/test/java/com/loopers/support/TestFixture.java
+++ b/apps/commerce-api/src/test/java/com/loopers/support/TestFixture.java
@@ -1,0 +1,38 @@
+package com.loopers.support;
+
+import com.loopers.domain.brand.Brand;
+import com.loopers.domain.product.Product;
+import com.loopers.domain.user.Gender;
+import com.loopers.domain.user.User;
+
+public class TestFixture {
+
+    public static User createUser() {
+        return User.create(
+                "oyy",
+                Gender.F,
+                "1999-08-21",
+                "loopers@gmail.com"
+        );
+    }
+
+    public static Brand createBrand() {
+        return Brand.create(
+                "나이키",
+                "스포츠브랜드",
+                "https://example.com/logo.png"
+        );
+    }
+
+    public static Product createProduct(Brand brand) {
+        return Product.create(
+                brand,
+                "나이키조던",
+                "운동화",
+                "https://example.com/logo.png",
+                1000,
+                10
+        );
+    }
+
+}


### PR DESCRIPTION
## 📌 Summary
- 브랜드&상품, 좋아요, 주문/결제 api 구현
- 브랜드&상품, 좋아요, 주문/결제 테스트 작성

## 💬 Review Points
❓ 도메인 간 결합을 어디까지 허용해도 될까요?
> 도메인 간 책임과 위임을 고려하며 코드를 작성하다 보면, 현실적으로 도메인 간 결합이 불가피한 상황이 생기기도 하는 것 같습니다.
이런 경우에는 어느 정도의 결합은 허용해도 괜찮은지, 혹은 반드시 피해야 하는 기준이 있다면 어떤 것들이 있을지 궁금합니다.
결합을 허용해도 되는 상황과 꼭 피해야 하는 상황에 대해 조언 부탁드립니다!

❓Factory로 행위 책임을 나누었는데 괜찮은 방법일까요?
> 현재 orderItemFactory를 활용하여 orderItem 생성과 관련된 책임을 도메인 외부로 분리해두었는데요,
이런 방식 외에도 도메인 내부에서 책임을 더 자연스럽게 나누거나 위임할 수 있는 다른 방법이 있을지 궁금합니다.
혹시 추천해주실 다른 접근 방식이나, 이 구조에서 개선해볼 수 있는 방향이 있다면 조언 부탁드립니다!

❓OOP 방식과 DDD 관점에서 도메인 간 책임 분리를 어떻게 바라봐야 할까요?
> 주문 기능을 구현하면서, 도메인 간 협력은 orderFacade에서 조율하고, orderService는 핵심 로직을 도메인 객체에 위임하는 방식으로 구성했습니다. 
예를 들어 orderService에서는 주문 생성, 재고 차감, 포인트 차감 등의 처리를 조율만 하고, 실제 비즈니스 로직은 order, product, point 등 도메인 객체 내부에서 수행되도록 했습니다.
전반적으로 OOP 스타일에 가깝다고 느껴지는데, DDD 관점에서 이 구조가 적절한지, 혹시 현재 구조에서 개선할 점이 있다면 피드백 부탁드립니다!

❓ 계층 간 DTO 변환이 반복될 때, 더 나은 구조가 있을까요?
> 각 레이어마다 DTO를 새로 정의하거나 감싸는 작업이 반복되고 있습니다.
내부 도메인 모델을 직접 노출하지 않기 위해 변환 메서드를 사용하여 각 계층 전용 DTO를 만들어 처리하고 있는데요,
점점 이런 변환이 과도하게 느껴지고, 중복도 많아져서 유지보수에 부담이 될 수 있겠다는 생각이 들었습니다.
DDD나 클린 아키텍처 관점에서 이런 구조가 괜찮은지, 혹은 더 나은 방식이나 대체 가능한 전략이 있다면 조언을 듣고 싶습니다!

## ✅ Checklist
- 1️⃣ 브랜드&상품
  - api 구현 [`ed0df1a`](https://github.com/yuneong/e-commerce/commit/ed0df1a9ae0d58e8d2876584a2164730b8e90651), [`572fae7`](https://github.com/yuneong/e-commerce/commit/572fae74ec8e88eb00a4193ec4ca347de02de338), [`a5f941a`](https://github.com/yuneong/e-commerce/commit/a5f941ae37f5a3bafce043cdf491936d7da69092), [`683ceed`](https://github.com/yuneong/e-commerce/commit/683ceed9a1fcbbf7f0eb683477eec93016f6d98e)
  - 단위/통합 테스트 [`df08305`](https://github.com/yuneong/e-commerce/commit/df083057d09d6eb9445b839019b60df2afe6621c), [`8be8552`](https://github.com/yuneong/e-commerce/commit/8be85523dd230d943de1360df9a383fb39f77ce5)

- 2️⃣ 좋아요
  - api 구현 [`1030bbc`](https://github.com/yuneong/e-commerce/commit/1030bbc0b5a7ac01a56090b8e10e6b427554e354), [`f43884e`](https://github.com/yuneong/e-commerce/commit/f43884e725683fd4e15d78a8b1bd7af8a77c05d8), [`9fe7150`](https://github.com/yuneong/e-commerce/commit/9fe715015fa49e308e1f364ec956d359a5f5f701), [`a3131bc`](https://github.com/yuneong/e-commerce/commit/a3131bc01a798b6182e5eb65a745b9d557dff4db)
  - 단위/통합 테스트 [`4bb838b`](https://github.com/yuneong/e-commerce/commit/4bb838b4594c5b5eee94837c7dc7673b0f606a60)

- 3️⃣ 주문/결제
  - api 구현 [`f3b06cb`](https://github.com/yuneong/e-commerce/commit/f3b06cbbf53de953ef8960bd2541ed9ba6594fe5)
  - 단위/통합 테스트 [`a1858af`](https://github.com/yuneong/e-commerce/commit/a1858afb13f04b79d71f93af5b99f5f5990ccb00)
 
- 4️⃣ 장바구니
  - api 구현 [`cb6e423`](https://github.com/yuneong/e-commerce/commit/cb6e42345b9b456f28e213f68c5d53ba25483e36)
  - 단위/통합 테스트 [`469e63b`](https://github.com/yuneong/e-commerce/commit/469e63b0a7c9c1f322c6e208b7a3ce1a90b37984)
 
- 5️⃣ 포인트
  - api 구현 [`859371c`](https://github.com/yuneong/e-commerce/commit/859371c30a7d52960c6f1f06711f2be07c61d27f), [`2f54651`](https://github.com/yuneong/e-commerce/commit/2f546519295ea25b1914f036b33e3fa5174e2417)
  - 단위/통합 테스트 [`8be8552`](https://github.com/yuneong/e-commerce/commit/8be85523dd230d943de1360df9a383fb39f77ce5)
